### PR TITLE
Fixed build metadata tests

### DIFF
--- a/tests/semver_test.py
+++ b/tests/semver_test.py
@@ -67,9 +67,8 @@ class TestSemver(TestCase):
         # < 1.3.7+build.2.b8f12d7 < 1.3.7+build.11.e0f985a
         # and in backward too.
         chain = ['1.0.0-alpha', '1.0.0-alpha.1', '1.0.0-beta.2',
-                 '1.0.0-beta.11', '1.0.0-rc.1', '1.0.0-rc.1+build.1',
-                 '1.0.0', '1.0.0+0.3.7', '1.3.7+build', '1.3.7+build.2.b8f12d7',
-                 '1.3.7+build.11.e0f985a']
+                 '1.0.0-beta.11', '1.0.0-rc.1',
+                 '1.0.0', '1.3.7+build']
         versions = zip(chain[:-1], chain[1:])
         for low_version, high_version in versions:
             self.assertEqual(


### PR DESCRIPTION
- removed tests that relied on build metadata not being ignored
