### PR TITLE
(not semver) Add support for dot in patch part and major.minor and major version only in lenient mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,70 @@ This module provides just couple of functions, main of which are:
     >>> semver.min_ver("1.0.0", "2.0.0")
     '1.0.0'
 
+The version 1.7.4 supports lenient mode for these versions:
+* major.minor. For e.g: 1.0
+* dot in patch. For e.g: 5.2.6.Final, 2.0.4.RELEASE
+
+By default the lenient mode is false, if you want to have these above support, you need to turn on the lenient mode by
+calling method:
+
+.. code-block:: python
+
+    semver.set_lenient(True)
+
+
+Below are examples with lenient mode is False:
+
+.. code-block:: python
+
+    >>> import semver
+    >>> semver.parse("1")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "semver.py", line 99, in parse
+        raise ValueError('%s is not valid SemVer string' % version)
+    ValueError: 1 is not valid SemVer string
+    >>> semver.parse("1.0")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "semver.py", line 132, in parse
+        raise ValueError('%s is not valid SemVer string' % version)
+    ValueError: 1.0 is not valid SemVer string
+    >>> semver.parse("1.0.0.FINAL")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "semver.py", line 132, in parse
+        raise ValueError('%s is not valid SemVer string' % version)
+    ValueError: 1.0.0.FINAL is not valid SemVer string
+    >>> semver.parse("5.2.6.Final")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "semver.py", line 132, in parse
+        raise ValueError('%s is not valid SemVer string' % version)
+    ValueError: 5.2.6.Final is not valid SemVer string
+    >>> semver.parse("2.0.4.RELEASE")
+    Traceback (most recent call last):
+      File "<stdin>", line 1, in <module>
+      File "semver.py", line 132, in parse
+        raise ValueError('%s is not valid SemVer string' % version)
+    ValueError: 2.0.4.RELEASE is not valid SemVer string
+
+
+Below are examples when we turn on lenient mode:
+
+.. code-block:: python
+
+    >>> import semver
+    >>> semver.set_lenient(True)
+    >>> semver.parse("1")
+    {'major': 1, 'prerelease': None, 'build': None, 'minor': 0, 'patch': 0}
+    >>> semver.parse("1.0")
+    {'major': 1, 'prerelease': None, 'build': None, 'minor': 0, 'patch': 0}
+    >>> semver.parse("5.2.6.Final")
+    {'major': 5, 'prerelease': None, 'build': 'Final', 'minor': 2, 'patch': 6}
+    >>> semver.parse("2.0.4.RELEASE")
+    {'major': 2, 'prerelease': None, 'build': 'RELEASE', 'minor': 0, 'patch': 4}
+
 Installation
 ------------
 

--- a/tests.py
+++ b/tests.py
@@ -11,6 +11,7 @@ from semver import bump_prerelease
 from semver import bump_build
 from semver import min_ver
 from semver import max_ver
+from semver import set_lenient
 
 
 def test_should_parse_version():
@@ -243,3 +244,66 @@ def test_should_bump_build():
     assert bump_build('3.4.5-rc.1+0009.dev') == '3.4.5-rc.1+0010.dev'
     assert bump_build('3.4.5-rc.1') == '3.4.5-rc.1+build.1'
     assert bump_build('3.4.5') == '3.4.5+build.1'
+
+
+def test_parse_version_has_major_and_minor_only():
+    set_lenient(True)
+    version_info = parse('1.0')
+    assert version_info['major'] == 1
+    assert version_info['minor'] == 0
+    set_lenient(False)
+
+
+def test_parse_version_with_patch_has_plus():
+    set_lenient(True)
+    version_info = parse('3.4.5+Final')
+    assert version_info['major'] == 3
+    assert version_info['minor'] == 4
+    assert version_info['patch'] == 5
+    assert version_info['build'] == 'Final'
+    set_lenient(False)
+
+
+def test_parse_version_with_patch_has_dot():
+    set_lenient(True)
+    version_info = parse('3.4.5.Final')
+    assert version_info['major'] == 3
+    assert version_info['minor'] == 4
+    assert version_info['patch'] == 5
+    assert version_info['build'] == 'Final'
+    set_lenient(False)
+
+
+def test_compare_versions_having_major_only():
+    set_lenient(True)
+    assert compare('1', '1.0') == 0
+    assert compare('1', '1.0.0') == 0
+    assert compare('1.1', '1') == 1
+    set_lenient(False)
+
+
+def test_compare_versions_having_major_and_minor_only():
+    set_lenient(True)
+    assert compare('1.0', '2.0') == -1
+    assert compare('2.0', '1.0') == 1
+    assert compare('2.0', '2.0') == 0
+    assert compare('2.0', '2.0.0') == 0
+    set_lenient(False)
+
+
+def test_compare_versions_with_patch_has_plus():
+    set_lenient(True)
+    assert compare('3.4.5+Final', '3.4.5') == 0
+    assert compare('3.4.5+Final', '3.4.6') == -1
+    assert compare('3.4.5+Final', '3.4.4') == 1
+    assert compare('3.4.5+Final', '3.4.5.Final') == 0
+    set_lenient(False)
+
+
+def test_compare_versions_with_patch_has_dot():
+    set_lenient(True)
+    assert compare('3.4.5.Final', '3.4.5') == 0
+    assert compare('3.4.5.Final', '3.4.6') == -1
+    assert compare('3.4.5.Final', '3.4.4') == 1
+    assert compare('3.4.5.Final', '3.4.5.Final') == 0
+    set_lenient(False)


### PR DESCRIPTION
Add support for "." in patch and major.minor version or major only in lenient mode
For example: 1, 1.0, 3.4.5.Final, 4.2.5.RELEASE