### PR TITLE
(not semver) Support complex filters

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -195,6 +195,38 @@ def match(version, match_expr):
     return cmp_res in possibilities
 
 
+def match_all(version, match_exprs):
+    """Compare a version with a list of expressions
+
+    :param str version: a version string
+    :param list match_exprs: list of operators, see match(version, match_expr)
+    :return: True if all expressions match the version, otherwise False
+    :rtype: bool
+    """
+    for expr in match_exprs:
+        if not match(version, expr):
+            return False
+    else:
+        return True
+
+
+def match_expr(version, match_expr):
+    """Compare a version with an expression
+
+    :param str version: a version string
+    :param str match_expr: an expression that specifies version ranges
+          example: >1.0.0,<=1.2.3|>2.0.0,<=2.4.5
+          matches versions between 1.0.0 and 1.2.3 or between 2.0.0 and 2.4.5
+    :return: True if the expression matches the version, otherwise False
+    :rtype: bool
+    """
+    for exprs in match_expr.split('|'):
+        if match_all(version, exprs.split(',')):
+            return True
+    else:
+        return False
+
+
 def max_ver(ver1, ver2):
     """Returns the greater version of two versions
 

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,8 @@ import pytest  # noqa
 
 from semver import compare
 from semver import match
+from semver import match_all
+from semver import match_expr
 from semver import parse
 from semver import format_version
 from semver import bump_major
@@ -102,6 +104,19 @@ def test_should_match_not_equal():
     assert match("2.3.7", "!=2.3.8") is True
     assert match("2.3.7", "!=2.3.6") is True
     assert match("2.3.7", "!=2.3.7") is False
+
+
+def test_should_match_all():
+    assert match_all("2.3.7", [">2.0.0", "<=2.4.0"]) is True
+    assert match_all("2.3.7", [">2.0.0", "<=2.1.3"]) is False
+    assert match_all("2.3.7", ["<=1.0.0", ">3.0.0"]) is False
+
+
+def test_should_match_expr():
+    assert match_expr("2.3.7", ">2.0.0,<=2.9.0") is True
+    assert match_expr("2.3.7", "<2.0.0,>3.0.0") is False
+    assert match_expr("2.3.7", ">1.0.0,<1.5.0|>2.0.0,<=2.3.9") is True
+    assert match_expr("2.3.7", ">1.0.0,<1.5.0|>3.0.0,<=3.2.1") is False
 
 
 def test_should_not_raise_value_error_for_expected_match_expression():


### PR DESCRIPTION
Implements #52.

This currently doesn't cover my usecase as I'd have to pass a custom function to pre-process non-semver complient versions.