### PR TITLE
Add note for GH repo to new python-semver org

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Features
 --------
 
 * :gh:`177` (:pr:`178`): Fixed repository and CI links (moved https://github.com/k-bx/python-semver/ repository to https://github.com/python-semver/python-semver/)
+* :pr:`179`: Added note about moving this project to the new python-semver organization on GitHub
 
 Bug Fixes
 ---------

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,18 @@ A Python module for `semantic versioning`_. Simplifies comparing versions.
 
 .. teaser-end
 
+.. note::
+
+   With version 2.9.0 we've moved the GitHub project. The project is now
+   located under the organization ``python-semver``.
+   The complete URL is::
+
+       https://github.com/python-semver/python-semver
+
+   If you still have an old repository, correct your upstream URL to the new URL::
+
+       $ git remote set-url upstream git@github.com:python-semver/python-semver.git
+
 
 The module follows the ``MAJOR.MINOR.PATCH`` style:
 


### PR DESCRIPTION
This PR extends the README with a note about the move to a new GH organization.

Mentioned in #177 and #178