### PR TITLE
Correct logo width, add white background

### DIFF
--- a/docs/_static/css/default.css
+++ b/docs/_static/css/default.css
@@ -1,0 +1,6 @@
+/* Customize logo width */
+
+.wy-side-nav-search > a img.logo {
+	width: 6em;
+	background: white;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -109,6 +109,8 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_css_files = ['css/default.css']
+
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
 #


### PR DESCRIPTION
This PR contains a fix to correct the logo:

* Correct the size of the logo
* Add white background

I don't know if this is the preferred method. However, I haven't found a configuration option to modify the size of a logo.

Example screenshot

----

![logo-size](https://user-images.githubusercontent.com/1312925/68751953-cac79480-0602-11ea-80d7-5fd46f8cf71a.png)
