### PR TITLE
Fix "pysemver" and "pysemver bump" when called without arguments

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ Features
 Bug Fixes
 ---------
 
+* :gh:`192` (:pr:`193`): Fixed "pysemver" and "pysemver bump" when called without arguments
+
+
 Removals
 --------
 

--- a/semver.py
+++ b/semver.py
@@ -676,7 +676,6 @@ def createparser():
         p.add_argument("version",
                        help="Version to raise"
                        )
-
     return parser
 
 
@@ -690,13 +689,21 @@ def process(args):
     :return: result of the selected action
     :rtype: str
     """
-    if args.which == "bump":
+    if not hasattr(args, "which"):
+        args.parser.print_help()
+        raise SystemExit()
+    elif args.which == "bump":
         maptable = {'major': 'bump_major',
                     'minor': 'bump_minor',
                     'patch': 'bump_patch',
                     'prerelease': 'bump_prerelease',
                     'build': 'bump_build',
                     }
+        if args.bump is None:
+            # When bump is called without arguments,
+            # print the help and exit
+            args.parser.parse_args([args.which, "-h"])
+
         ver = parse_version_info(args.version)
         # get the respective method and call it
         func = getattr(ver, maptable[args.bump])
@@ -716,7 +723,8 @@ def main(cliargs=None):
     try:
         parser = createparser()
         args = parser.parse_args(args=cliargs)
-        # args.parser = parser
+        # Save parser instance:
+        args.parser = parser
         result = process(args)
         print(result)
         return 0

--- a/test_semver.py
+++ b/test_semver.py
@@ -658,6 +658,16 @@ def test_should_process_raise_error(capsys):
     assert captured.err.startswith("ERROR")
 
 
+def test_should_raise_systemexit_when_called_with_empty_arguments():
+    with pytest.raises(SystemExit):
+        main([])
+
+
+def test_should_raise_systemexit_when_bump_iscalled_with_empty_arguments():
+    with pytest.raises(SystemExit):
+        main(["bump"])
+
+
 @pytest.mark.parametrize("version,parts,expected", [
     ("3.4.5", dict(major=2), '2.4.5'),
     ("3.4.5", dict(major="2"), '2.4.5'),


### PR DESCRIPTION
This PR fixes #192 and contains the following changes:

* Raise SystemExit when `pysemver` is called without arguments.
* When `pysemver bump` is called without arguments, print the help text for the bump subcommand and exit.
* Add test cases for both calls.

Without this patch, `pysemver bump` raises an AttributeError:

```
Traceback (most recent call last):
  File ".tox/py36/bin/pysemver", line 8, in <module>
    sys.exit(main())
  File ".tox/py36/lib/python3.6/site-packages/semver.py", line 726, in main
    result = process(args)
  File ".tox/py36/lib/python3.6/site-packages/semver.py", line 693, in process
    if args.which == "bump":
AttributeError: 'Namespace' object has no attribute 'which'
```

---

Funny sidenote: I discovered this bug when trying to document the manpage. :wink:  Documenting reveals bugs! :smile: 