### PR TITLE
Add distribution specific install hints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Features
 * :pr:`179`: Added note about moving this project to the new python-semver organization on GitHub
 * :gh:`187` (:pr:`188`): Added logo for python-semver organization and documentation
 * :gh:`191` (:pr:`194`): Created manpage for pysemver
+* :gh:`196` (:pr:`197`): Added distribution specific installation instructions
+
 
 Bug Fixes
 ---------

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,3 +12,79 @@ For Python 3:
 .. code-block:: bash
 
     pip3 install semver
+
+
+.. note::
+
+   Some Linux distributions can have outdated packages.
+   These outdated packages does not contain the latest bug fixes or new features.
+   If you need a newer package, you have these option:
+
+    * Ask the maintainer to update the package.
+    * Update the package for your favorite distribution and submit it.
+    * Use a Python virtual environment and :command:`pip install`.
+
+
+Arch Linux
+----------
+
+1. Enable the community repositories first:
+
+   .. code-block:: ini
+
+      [community]
+      Include = /etc/pacman.d/mirrorlist
+
+2. Install the package::
+
+    $ pacman -Sy python-semver
+
+
+Debian
+------
+
+1. Update the package index::
+
+    $  sudo apt-get update
+
+2. Install the package::
+
+    $ sudo apt-get install python3-semver
+
+
+Fedora
+------
+
+.. code-block:: bash
+
+    $ dnf install python3-semver
+
+
+FreeBSD
+-------
+
+.. code-block:: bash
+
+
+openSUSE
+--------
+
+1. Enable the the ``devel:languages:python`` repository on the Open Build Service (replace ``<VERSION>`` with the preferred openSUSE release)::
+
+    $ zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_<VERSION>/devel:languages:python.repo
+
+2. Install the package::
+
+    $ zypper --repo devel_languages_python python3-semver
+
+
+Ubuntu
+------
+
+1. Update the package index::
+
+    $ sudo apt-get update
+
+2. Install the package::
+
+    $ sudo apt-get install python3-semver


### PR DESCRIPTION
This PR fixes #196 

* Improve the installation section and add installation instructions for Arch Linux, Debian, Fedora, FreeBSD, openSUSE, and Ubuntu.
* Adapt `CHANGELOG.rst`

----

I've mostly used the installation instructions from https://pkgs.org, but I'm not sure if this is all correct (I mainly use openSUSE). So please check, if this is ok.
