### PR TITLE
Fix #194 and #114: Update semver regex to version from semver.org

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -19,18 +19,18 @@ __maintainer_email__ = "s.celles@gmail.com"
 _REGEX = re.compile(
         r"""
         ^
-        (?P<major>(?:0|[1-9][0-9]*))
+        (?P<major>0|[1-9]\d*)
         \.
-        (?P<minor>(?:0|[1-9][0-9]*))
+        (?P<minor>0|[1-9]\d*)
         \.
-        (?P<patch>(?:0|[1-9][0-9]*))
-        (\-(?P<prerelease>
-            (?:0|[1-9A-Za-z-][0-9A-Za-z-]*)
-            (\.(?:0|[1-9A-Za-z-][0-9A-Za-z-]*))*
+        (?P<patch>0|[1-9]\d*)
+        (?:-(?P<prerelease>
+            (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
+            (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
         ))?
-        (\+(?P<build>
-            [0-9A-Za-z-]+
-            (\.[0-9A-Za-z-]+)*
+        (?:\+(?P<build>
+            [0-9a-zA-Z-]+
+            (?:\.[0-9a-zA-Z-]+)*
         ))?
         $
         """, re.VERBOSE)

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ class Tox(TestCommand):
 
 class Clean(CleanCommand):
     def run(self):
-        super().run()
+        super(CleanCommand, self).run()
         delete_in_root = [
             'build',
             '.cache',

--- a/test_semver.py
+++ b/test_semver.py
@@ -70,6 +70,30 @@ def test_fordocstrings(func):
         'prerelease': 'alpha-1',
         'build': 'build.11.e0f985a',
         }),
+    ("0.1.0-0f",
+     {
+         'major': 0,
+         'minor': 1,
+         'patch': 0,
+         'prerelease': '0f',
+         'build': None,
+     }),
+    ("0.0.0-0foo.1",
+     {
+         'major': 0,
+         'minor': 0,
+         'patch': 0,
+         'prerelease': '0foo.1',
+         'build': None,
+     }),
+    ("0.0.0-0foo.1+build.1",
+     {
+         'major': 0,
+         'minor': 0,
+         'patch': 0,
+         'prerelease': '0foo.1',
+         'build': 'build.1',
+     }),
 ])
 def test_should_parse_version(version, expected):
     result = parse(version)


### PR DESCRIPTION
I took a regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string , splitted it into multiple lines to match current format and renamed `buildmetadata` -> `build`. Also, I found and fix a problem with invalid Python 2.7 super call :)