### PR TITLE
Extend #186: Add GitHub Action for black formatter

### DIFF
--- a/.github/workflows/black-formatting.yml
+++ b/.github/workflows/black-formatting.yml
@@ -1,0 +1,49 @@
+name: Black Formatting
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Output env variables
+        run: |
+           echo "GITHUB_WORKFLOW=${GITHUB_WORKFLOW}"
+           echo "GITHUB_ACTION=$GITHUB_ACTION"
+           echo "GITHUB_ACTIONS=$GITHUB_ACTIONS"
+           echo "GITHUB_ACTOR=$GITHUB_ACTOR"
+           echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
+           echo "GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME"
+           echo "GITHUB_EVENT_PATH=$GITHUB_EVENT_PATH"
+           echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+           echo "GITHUB_SHA=$GITHUB_SHA"
+           echo "GITHUB_REF=$GITHUB_REF"
+           echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
+           echo "GITHUB_BASE_REF=$GITHUB_BASE_REF"
+           echo "::debug::---Start content of file $GITHUB_EVENT_PATH"
+           cat $GITHUB_EVENT_PATH
+           echo "\n"
+           echo "::debug::---end"
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip black
+
+      - name: Run black
+        id: black
+        run: |
+          black . > project.diff
+          echo "::set-output name=rc::$?"
+
+      - name: Upload diff artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: black-project-diff
+          path: project.diff


### PR DESCRIPTION
## Scope

This PR is a first start of GH Actions to call the `black` source code formatter and does basically this:

1. Triggered by a pull request event.
2. Setup Python 3.7.
3. Install black.
4. Run black and create a diff file.
5. Upload the diff as artifact; this can be downloaded and examined if needed. See my [action run in my fork](https://github.com/tomschr/python-semver/pull/2/checks?check_run_id=318204067).

For the time being, it's quite "simple". This was on purpose as I've played with other fancy stuff which didn't work as expected (probably it was my fault because this topic is quite new for me).

From a design point of view, it is built upon other actions, created by GitHub itself.

At the moment, black creates a >50KB diff of the source code of all `*.py` files. Maybe we should create another issue to (re)format the source code with black to reduce the diff for future pull requests.

## Not Implemented Ideas

I've played around in my fork to implement other more fancy tasks. However, the result were mixed. That's why I thought I start with something more simple. If wanted, we can extend it later. :wink: 

To create your own Action you either a) reuse existing Actions, or b) create your own. I've tried to start with a) first as for b) you need to know JavaScript or Docker.

I've tried the following, but didn't include it into this PR:

* Add the diff as a comment
  I've tried to add a comment and the diff to a pull request. That would be nice so the owner of the PR would see the result from the GH Action. The comment was visible, but not the diff. For some unknown reason, I couldn't pass the result from the black step into the commenting step.

  As the diff can be quite huge, it would add a lot of "noise" to the comments. One way to avoid it would be to add only the first x lines or to use the program `filterdiff`. That can extract the first 2-4 "hunks" of a diff (use `filterdiff -#3 project.diff`). 

* Add pip caching
  Adding pip caching speeds up things. I've tested it, but it didn't work reliably for me.


## Future Ideas

If we add more GH Actions to the repo in the future, it would probably interesting to create our own Actions.

As we have now a python-semver organization, it is easy to create such additional repositories under our domain. This could be source code formatting, release code management, or something else.

I think, this is probably something we should consider in the future. With our own GH Actions, we have more finer control and the Actions are separated from the semver source code.

But this is something beyond this simple PR; I've added it here to have a place for future reference.