### PR TITLE
Fix #203: Use --check option for black (infra)

### DIFF
--- a/.github/workflows/black-formatting.yml
+++ b/.github/workflows/black-formatting.yml
@@ -39,11 +39,5 @@ jobs:
       - name: Run black
         id: black
         run: |
-          black . > project.diff
+          black --check .
           echo "::set-output name=rc::$?"
-
-      - name: Upload diff artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: black-project-diff
-          path: project.diff


### PR DESCRIPTION
This PR contains the following changes:

* Remove uploading the diff file as artifact
* Use `--check` to test our source code

---

I haven't provided an entry in the CHANGELOG. It doesn't affect the source code and it's not bound to a specific release, so I thought I skip this. Hope this is ok. :wink: 