### PR TITLE
Improve consistency in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist =
     pypy
 
 [testenv]
+description = Run test suite
+whitelist_externals = make
 commands = pytest {posargs:}
 deps =
     pytest
@@ -12,19 +14,27 @@ deps =
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
 
+[testenv:black]
+description = Check for formatting changes
+basepython = python3
+deps = black
+commands = black --check {posargs:.}
+
 [testenv:flake8]
+description = Check code style
 basepython = python3
 deps = flake8
-commands = flake8
+commands = flake8 {posargs:}
 
 [testenv:docs]
+description = Build HTML documentation
 basepython = python3
 deps = -r{toxinidir}/docs/requirements.txt
 skip_install = true
-commands = sphinx-build {posargs:-E} -b html docs dist/docs
+commands = make -C docs html
 
 [testenv:man]
-whitelist_externals = make
+description = Build the manpage
 basepython = python3
 deps = sphinx
 skip_install = true


### PR DESCRIPTION
This PR contains (not related to any issue):

* Describe each target with `description` keyword; useful when running `tox` as `tox -a -v`
* Move `whitelist_externals` to `textenv` section
* Use `make` in `docs` target instead of running `sphinx-build` directly
* Introduce `black` target to check for changes in formatting
* Use `posargs` for flake

---

I didn't update the CHANGELOG as it is not related to the source code, more about the infrastructure. For end-users, I think, it is not of much interest *how* we create this project (as long as we describe changes in the source code). Nevertheless, if this is still of interest, I could introduce a separate section ("Infrastructure").