### PR TITLE
Fix #208: Introduce VersionInfo.isvalid() function

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ Features
 * :gh:`191` (:pr:`194`): Created manpage for pysemver
 * :gh:`196` (:pr:`197`): Added distribution specific installation instructions
 * :gh:`201` (:pr:`202`): Reformatted source code with black
+* :gh:`208` (:pr:`209`): Introduce new function :func:`semver.VersionInfo.isvalid`
+  and extend :command:`pysemver` with :command:`check` subcommand
+
 
 Bug Fixes
 ---------
@@ -53,7 +56,6 @@ Features
 * :pr:`165`: Improved code coverage
 * :pr:`166`: Reworked :file:`.gitignore` file
 * :gh:`167` (:pr:`168`): Introduced global constant :data:`SEMVER_SPEC_VERSION`
-
 
 Bug Fixes
 ---------

--- a/docs/pysemver.rst
+++ b/docs/pysemver.rst
@@ -86,6 +86,29 @@ you get an error message and a return code != 0::
    ERROR 1.5 is not valid SemVer string
 
 
+pysemver check
+~~~~~~~~~~~~~~
+
+Checks if a string is a valid semver version.
+
+.. code:: bash
+
+   pysemver check <VERSION>
+
+.. option:: <VERSION>
+
+    The version string to check.
+
+The *error code* returned by the script indicates if the
+version is valid (=0) or not (!=0)::
+
+    $ pysemver check 1.2.3; echo $?
+    0
+    $ pysemver check 2.1; echo $?
+    ERROR Invalid version '2.1'
+    2
+
+
 pysemver compare
 ~~~~~~~~~~~~~~~~
 
@@ -120,7 +143,6 @@ are valid (return code 0) or not (return code != 0)::
     $ pysemver compare 1.2.3 2.4.0 ; echo $?
     ERROR 1.2.x is not valid SemVer string
     2
-
 
 See also
 --------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,6 +53,13 @@ A version can be created in different ways:
     >>> semver.VersionInfo(1, 2, 3, 4, 5)
     VersionInfo(major=1, minor=2, patch=3, prerelease=4, build=5)
 
+If you pass an invalid version string you will get a ``ValueError``::
+
+    >>> semver.parse("1.2")
+    Traceback (most recent call last)
+    ...
+    ValueError: 1.2 is not valid SemVer string
+
 
 Parsing a Version String
 ------------------------
@@ -75,6 +82,20 @@ Parsing a Version String
 
     >>> semver.parse("3.4.5-pre.2+build.4")
     {'major': 3, 'minor': 4, 'patch': 5,  'prerelease': 'pre.2', 'build': 'build.4'}
+
+
+Checking for a Valid Semver Version
+-----------------------------------
+
+If you need to check a string if it is a valid semver version, use the
+classmethod :func:`semver.VersionInfo.isvalid`:
+
+.. code-block:: python
+
+    >>> VersionInfo.isvalid("1.0.0")
+    True
+    >>> VersionInfo.isvalid("invalid")
+    False
 
 
 Accessing Parts of a Version


### PR DESCRIPTION
This PR fixes #208 and contains:

* `VersionInfo.isvalid(cls, version:str) -> bool`
* Add test case
* Describe function in documentation; also clarified in the "Creating a Version" what happens when the user pass an invalid version string.

As I expect some discussions and as this is still WIP, I haven't completed the CHANGELOG entry yet. :wink: 

---

Update 2019-12-08: Add entry in `CHANGELOG.rst`.

---

Update 2019-12-09: Insert `check` subcommand into `pysemver` command.