### PR TITLE
WIP: Create semver version 2.9.1-rc2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,10 +6,11 @@ Change Log
 All notable changes to this code base will be documented in this file,
 in every released version.
 
-Version 2.9.1 (WIP)
-===================
-:Released: 20xy-xy-xy
-:Maintainer: ...
+
+Version 2.9.1
+=============
+:Released: 2020-02-16
+:Maintainer: Tom Schraitle
 
 Features
 --------
@@ -33,6 +34,9 @@ Bug Fixes
 
 Removals
 --------
+
+not available
+
 
 Version 2.9.0
 =============

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,9 @@
-include README.rst
-include LICENSE.txt
+include *.rst
+include *.txt
 include test_*.py
+
+exclude .travis.yml
+prune docs/_build
+recursive-exclude .github  *
+
+global-exclude *.py[cod] __pycache__ *.so *.dylib

--- a/release-procedure.md
+++ b/release-procedure.md
@@ -21,6 +21,19 @@ Release procedure
 
 * Ensure that long description (ie [README.rst](https://github.com/python-semver/python-semver/blob/master/README.rst)) can be correctly rendered by Pypi using `restview --long-description`
 
+* Upload it to TestPyPI first:
+
+```bash
+git clean -xfd
+python setup.py register sdist bdist_wheel --universal
+twine upload --repository-url https://test.pypi.org/legacy/  dist/*
+```
+
+  If you have a `~/.pypirc` with a `testpyi` section, the upload can be
+  simplified:
+
+      twine upload --repository testpyi dist/*
+
 * Upload to PyPI
 
 ```bash

--- a/semver.py
+++ b/semver.py
@@ -8,10 +8,10 @@ import re
 import sys
 
 
-__version__ = "2.9.0"
+__version__ = "2.9.1"
 __author__ = "Kostiantyn Rybnikov"
 __author_email__ = "k-bx@k-bx.com"
-__maintainer__ = "Sebastien Celles"
+__maintainer__ = ["Sebastien Celles", "Tom Schraitle"]
 __maintainer_email__ = "s.celles@gmail.com"
 
 _REGEX = re.compile(

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
     include_package_data=True,
     license="BSD",
     classifiers=[
+        # See https://pypi.org/pypi?%3Aaction=list_classifiers
         "Environment :: Web Environment",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
This PR fixes #219:

* Raise version number in `__version__`
* Update CHANGELOG
* Mention TestPyPI in `release-procedure.md`
* MANIFEST.in:
  * Exclude `.travis.yml`
  * Exclude `.github` directory (pretty useless in an archive/wheel)
  * Exclude `docs/_build` directory
  * Exclude temporary Python files like `__pycache__`, `*.py[cod]`
  * Include all `*.txt` and `*.rst` files

---

Update 2020-02-16: Add missing issue number