### PR TITLE
First implementation of next_version

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -244,8 +244,8 @@ It is possible to convert a :class:`semver.VersionInfo` instance:
     (5, 4, 2, None, None)
 
 
-Increasing Parts of a Version
------------------------------
+Raising Parts of a Version
+--------------------------
 
 The ``semver`` module contains the following functions to raise parts of
 a version:
@@ -274,6 +274,30 @@ a version:
     '3.4.5-pre.2+build.5'
 
 Likewise the module level functions :func:`semver.bump_major`.
+
+
+Increasing Parts of a Version Taking into Account Prereleases
+-------------------------------------------------------------
+
+.. versionadded:: 2.10.0
+   Added :func:`semver.VersionInfo.next_version`.
+
+If you want to raise your version and take prereleases into account,
+the function :func:`semver.VersionInfo.next_version` would perhaps a
+better fit.
+
+
+.. code-block:: python
+
+    >>> v = semver.VersionInfo.parse("3.4.5-pre.2+build.4")
+    >>> str(v.next_version(part="prerelease"))
+    '3.4.5-pre.3'
+    >>> str(semver.VersionInfo.parse("3.4.5-pre.2+build.4").next_version(part="patch"))
+    '3.4.5'
+    >>> str(semver.VersionInfo.parse("3.4.5+build.4").next_version(part="patch"))
+    '3.4.5'
+    >>> str(semver.VersionInfo.parse("0.1.4").next_version("prerelease"))
+    '0.1.5-rc.1'
 
 
 Comparing Versions

--- a/test_semver.py
+++ b/test_semver.py
@@ -881,3 +881,39 @@ def test_deprecated_deco_without_argument():
 
     with pytest.deprecated_call():
         assert mock_func()
+
+
+def test_next_version_with_invalid_parts():
+    version = VersionInfo.parse("1.0.1")
+    with pytest.raises(ValueError):
+        version.next_version("invalid")
+
+
+@pytest.mark.parametrize(
+    "version, part, expected",
+    [
+        # major
+        ("1.0.4-rc.1", "major", "2.0.0"),
+        ("1.1.0-rc.1", "major", "2.0.0"),
+        ("1.1.4-rc.1", "major", "2.0.0"),
+        ("1.2.3", "major", "2.0.0"),
+        ("1.0.0-rc.1", "major", "1.0.0"),
+        # minor
+        ("0.2.0-rc.1", "minor", "0.2.0"),
+        ("0.2.5-rc.1", "minor", "0.3.0"),
+        ("1.3.1", "minor", "1.4.0"),
+        # patch
+        ("1.3.2", "patch", "1.3.3"),
+        ("0.1.5-rc.2", "patch", "0.1.5"),
+        # prerelease
+        ("0.1.4", "prerelease", "0.1.5-rc.1"),
+        ("0.1.5-rc.1", "prerelease", "0.1.5-rc.2"),
+        # special cases
+        ("0.2.0-rc.1", "patch", "0.2.0"),  # same as "minor"
+        ("1.0.0-rc.1", "patch", "1.0.0"),  # same as "major"
+        ("1.0.0-rc.1", "minor", "1.0.0"),  # same as "major"
+    ],
+)
+def test_next_version_with_versioninfo(version, part, expected):
+    ver = VersionInfo.parse(version)
+    assert str(ver.next_version(part)) == expected


### PR DESCRIPTION
This PR contains (based on #221):

* Implement semver.next_version(version, part, *, prerelease_token="rc")
* Add test cases

TODOs:

* [x] Implement `semver.VersionInfo.next_version` counterpart
* [ ] Describe the function(s) in our documentation

----
@gsakkis This is a first draft, feel free to comment. :wink: 