### PR TITLE
Fix #224: Replace super() call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,25 @@ Change Log
 All notable changes to this code base will be documented in this file,
 in every released version.
 
+Version 2.9.x (WIP)
+===================
+
+:Released: 2020-xx-yy
+:Maintainer:
+
+Features
+--------
+
+Bug Fixes
+---------
+
+* :gh:`224` (:pr:`226`): Replaced in class ``clean``, ``super(CleanCommand, self).run()`` with  
+   ``CleanCommand.run(self)``
+
+
+Removals
+--------
+
 
 Version 2.9.1
 =============

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ class Tox(TestCommand):
 
 class Clean(CleanCommand):
     def run(self):
-        super(CleanCommand, self).run()
+        CleanCommand.run(self)
         delete_in_root = ["build", ".cache", "dist", ".eggs", "*.egg-info", ".tox"]
         delete_everywhere = ["__pycache__", "*.pyc"]
         for candidate in delete_in_root:


### PR DESCRIPTION
This PR is a first attempt to fix #224 and contains:

* In class clean, replace super(CleanCommand, self).run() with CleanCommand.run(self)
  Co-authored-by: Dennis Menschel <menschel-d>

@menschel-d could you try this branch and test it?