### PR TITLE
Add better doctest integration into pytest

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,9 +18,14 @@ Features
 Bug Fixes
 ---------
 
-* :gh:`224` (:pr:`226`): Replaced in class ``clean``, ``super(CleanCommand, self).run()`` with  
-   ``CleanCommand.run(self)``
+* :gh:`224` (:pr:`226`): In ``setup.py``, replaced in class ``clean``,
+  ``super(CleanCommand, self).run()`` with ``CleanCommand.run(self)``
 
+
+Additions
+---------
+
+* :pr:`228`: Added better doctest integration
 
 Removals
 --------

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ different parts, use the `semver.parse` function:
     >>> ver['prerelease']
     'pre.2'
     >>> ver['build']
-    'build.5'
+    'build.4'
 
 To raise parts of a version, there are a couple of functions available for
 you. The `semver.parse_version_info` function converts a version string
@@ -87,7 +87,7 @@ It is allowed to concatenate different "bump functions":
 .. code-block:: python
 
     >>> ver.bump_major().bump_minor()
-    VersionInfo(major=4, minor=0, patch=1, prerelease=None, build=None)
+    VersionInfo(major=4, minor=1, patch=0, prerelease=None, build=None)
 
 To compare two versions, semver provides the `semver.compare` function.
 The return value indicates the relationship between the first and second

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,13 @@
 import pytest
 import semver
+import sys
+
+sys.path.insert(0, "docs")
+
+from coerce import coerce  # noqa:E402
 
 
 @pytest.fixture(autouse=True)
 def add_semver(doctest_namespace):
     doctest_namespace["semver"] = semver
+    doctest_namespace["coerce"] = coerce

--- a/docs/coerce.py
+++ b/docs/coerce.py
@@ -1,0 +1,42 @@
+import re
+import semver
+
+BASEVERSION = re.compile(
+    r"""[vV]?
+        (?P<major>0|[1-9]\d*)
+        (\.
+        (?P<minor>0|[1-9]\d*)
+        (\.
+            (?P<patch>0|[1-9]\d*)
+        )?
+        )?
+    """,
+    re.VERBOSE,
+)
+
+
+def coerce(version):
+    """
+    Convert an incomplete version string into a semver-compatible VersionInfo
+    object
+
+    * Tries to detect a "basic" version string (``major.minor.patch``).
+    * If not enough components can be found, missing components are
+        set to zero to obtain a valid semver version.
+
+    :param str version: the version string to convert
+    :return: a tuple with a :class:`VersionInfo` instance (or ``None``
+        if it's not a version) and the rest of the string which doesn't
+        belong to a basic version.
+    :rtype: tuple(:class:`VersionInfo` | None, str)
+    """
+    match = BASEVERSION.search(version)
+    if not match:
+        return (None, version)
+
+    ver = {
+        key: 0 if value is None else value for key, value in match.groupdict().items()
+    }
+    ver = semver.VersionInfo(**ver)
+    rest = match.string[match.end() :]  # noqa:E203
+    return ver, rest

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -174,6 +174,7 @@ documentation includes:
             1
             >>> semver.compare("2.0.0", "2.0.0")
             0
+
             """
 
   * **The documentation**

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,11 @@
 [tool:pytest]
 norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .eggs/
+testpaths = . docs
 addopts =
-    --ignore=.eggs/
     --no-cov-on-fail
     --cov=semver
     --cov-report=term-missing
+    --doctest-glob='*.rst'
     --doctest-modules
     --doctest-report ndiff
 


### PR DESCRIPTION
This PR is not based on a specific issue; it just evolved after having the idea of better integrate doctests in our documentation with pytest. :wink: 

Our documentation contains some examples which can be considered as doctests. As pytest supports doctests, we could use this features to check if the examples in our documentation are still correct.

This PR contains the following changes:

* Fix typos in `README.rst`.
* Move `coerce()` function into separate file; this was needed so it can be both included into the documentation and inside `conftest.py`.
* In `docs/usage.rst`:
  - Fix typos
  - Add missing semver module name as prefix
  - Slightly rewrite some doctests which involves dicts (unfortunately, order matters still in Python2).
* In `setup.cfg`:
  - Add `--doctest-glob` option to look for all `*.rst` files.
  - Add `testpaths` key to restrict testing paths to current dir and `docs`.

I think, this is a huge benefit as it reduces typos in our documentation or prevents outdated information (they would be reported as errors).
