### PR TITLE
Simplify openSUSE installation with obs://

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -84,9 +84,9 @@ FreeBSD
 openSUSE
 ^^^^^^^^
 
-1. Enable the the ``devel:languages:python`` repository on the Open Build Service (replace ``<VERSION>`` with the preferred openSUSE release)::
+1. Enable the ``devel:languages:python`` repository of the Open Build Service::
 
-    $ zypper addrepo https://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_<VERSION>/devel:languages:python.repo
+    $ zypper addrepo --refresh obs://devel:languages:python devel_languages_python
 
 2. Install the package::
 


### PR DESCRIPTION
Use `obs://` scheme instead of the longer `http://`. The former has the additional advantage, that the current release is automatically detected.

@m-rey: Would that be ok?