### PR TITLE
Fix #251: return VersionInfo for next_version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,34 @@ Change Log
 All notable changes to this code base will be documented in this file,
 in every released version.
 
+
+Version 2.10.1 (WIP)
+====================
+
+:Released: 2020-0x-0y
+:Maintainer:
+
+
+Features
+--------
+
+
+Bug Fixes
+---------
+
+* :gh:`251` (:pr:`000`): Fixed return type of ``semver.VersionInfo.next_version``
+  to always return a ``VersionInfo`` instance.
+
+
+Additions
+---------
+
+
+Removals
+--------
+
+
+
 Version 2.10.0
 ==============
 

--- a/semver.py
+++ b/semver.py
@@ -495,7 +495,7 @@ build='build.10')
             return version.replace(prerelease=None, build=None)
 
         if part in ("major", "minor", "patch"):
-            return str(getattr(version, "bump_" + part)())
+            return getattr(version, "bump_" + part)()
 
         if not version.prerelease:
             version = version.bump_patch()

--- a/test_semver.py
+++ b/test_semver.py
@@ -1050,4 +1050,6 @@ def test_next_version_with_invalid_parts():
 )
 def test_next_version_with_versioninfo(version, part, expected):
     ver = VersionInfo.parse(version)
-    assert str(ver.next_version(part)) == expected
+    nxt = ver.next_version(part)
+    assert isinstance(nxt, VersionInfo)
+    assert str(nxt) == expected


### PR DESCRIPTION
This PR fixes #251 and contains the following changes:

* Return `VersionInfo` instance in `VersionInfo.next_version` and not str when part is major, minor, or patch.
* Change `test_next_version_with_versioninfo`: Test for correct return type (should be `VersionInfo`)

