### PR TITLE
Add type hints

### DIFF
--- a/semver.py
+++ b/semver.py
@@ -50,8 +50,8 @@ __all__ = (
 
 from types import FrameType
 
-from typing import Callable, TypeVar, SupportsInt, Protocol, Optional, Tuple, Dict, Union, Generator, cast, Iterable, \
-    List, AnyStr
+from typing import Callable, TypeVar, SupportsInt, Optional, Tuple, Dict, Union, Generator, cast, Iterable, \
+    List
 
 #: Contains the implemented semver.org version of the spec
 SEMVER_SPEC_VERSION = "2.0.0"
@@ -167,11 +167,6 @@ def comparator(operator: Comparator) -> Comparator:
     return wrapper
 
 
-class SupportsString(Protocol):
-    def __str__(self):
-        ...
-
-
 class VersionInfo:
     """
     A semver compatible version class.
@@ -210,7 +205,7 @@ class VersionInfo:
     )
 
     def __init__(self, major: SupportsInt, minor: SupportsInt = 0, patch: SupportsInt = 0,
-                 prerelease: SupportsString = None, build: SupportsString = None):
+                 prerelease: Union[str, int] = None, build: Union[str, int] = None):
         self._major = int(major)
         self._minor = int(minor)
         self._patch = int(patch)


### PR DESCRIPTION
This adds type hints to every function not deprecated. Should fix #213 .

I've had to refactor some of the code to get mypy to stop complaining on python 3.8. It isn't configured in Tox yet because I am waiting on #247 to be merged to avoid conflicts.
