### PR TITLE
Refactor max_ver and min_ver to use builtin max and min

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -447,7 +447,7 @@ Other types cannot be compared.
 
 If you need to convert some types into others, refer to :ref:`sec.convert.versions`.
 
-The use of these comparison operators also implies that you can also use builtin
+The use of these comparison operators also implies that you can use builtin
 functions that leverage this capability; builtins including but not limited to: :func:`max`, :func:`min`
 (refer to :ref:`sec_max_min` for examples) and :func:`sorted`.
 
@@ -482,10 +482,11 @@ That gives you the following possibilities to express your condition:
 
 .. _sec_max_min:
 
-Getting Minimum and Maximum of multiple Versions
+Getting Minimum and Maximum of Multiple Versions
 -------------------------------------------
-*Changed in version 2.10.2:* :func:`semver.max_ver` and :func:`semver.min_ver` functions are deprecated in favor of their builtin counterparts
-:func:`max` and :func:`min`.
+.. versionchanged:: 2.10.2
+   The functions :func:`semver.max_ver` and :func:`semver.min_ver` are deprecated in
+   favor of their builtin counterparts :func:`max` and :func:`min`.
 
 Since :class:`semver.VersionInfo` implements :func:`__gt__()` and :func:`__lt__()`, it can be used with builtins requiring
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -480,9 +480,9 @@ That gives you the following possibilities to express your condition:
     >>> semver.match("1.0.0", ">1.0.0")
     False
 
-.. _sec_max_min
+.. _sec_max_min:
 
-Getting Minimum and Maximum of two Versions
+Getting Minimum and Maximum of multiple Versions
 -------------------------------------------
 *Changed in version 2.10.2:* :func:`semver.max_ver` and :func:`semver.min_ver` functions are deprecated in favor of their builtin counterparts
 :func:`max` and :func:`min`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -448,8 +448,8 @@ Other types cannot be compared.
 If you need to convert some types into others, refer to :ref:`sec.convert.versions`.
 
 The use of these comparison operators also implies that you can use builtin
-functions that leverage this capability; builtins including but not limited to: :func:`max`, :func:`min`
-(refer to :ref:`sec_max_min` for examples) and :func:`sorted`.
+functions that leverage this capability; builtins including, but not limited to: :func:`max`, :func:`min`
+(for examples, see :ref:`sec_max_min`) and :func:`sorted`.
 
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,9 +11,9 @@ are met.
 Knowing the Implemented semver.org Version
 ------------------------------------------
 
-The semver.org page is the authorative specification of how semantical
-versioning is definied.
-To know which version of semver.org is implemented in the semver libary,
+The semver.org page is the authoritative specification of how semantic
+versioning is defined.
+To know which version of semver.org is implemented in the semver library,
 use the following constant::
 
    >>> semver.SEMVER_SPEC_VERSION
@@ -445,7 +445,7 @@ To compare two versions depends on your type:
 
 Other types cannot be compared.
 
-If you need to convert some types into other, refer to :ref:`sec.convert.versions`.
+If you need to convert some types into others, refer to :ref:`sec.convert.versions`.
 
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -447,6 +447,10 @@ Other types cannot be compared.
 
 If you need to convert some types into others, refer to :ref:`sec.convert.versions`.
 
+The use of these comparison operators also implies that you can also use builtin
+functions that leverage this capability; builtins including but not limited to: :func:`max`, :func:`min`
+(refer to :ref:`sec_max_min` for examples) and :func:`sorted`.
+
 
 
 Comparing Versions through an Expression
@@ -476,16 +480,28 @@ That gives you the following possibilities to express your condition:
     >>> semver.match("1.0.0", ">1.0.0")
     False
 
+.. _sec_max_min
 
 Getting Minimum and Maximum of two Versions
 -------------------------------------------
+*Changed in version 2.10.2:* :func:`semver.max_ver` and :func:`semver.min_ver` functions are deprecated in favor of their builtin counterparts
+:func:`max` and :func:`min`.
+
+Since :class:`semver.VersionInfo` implements :func:`__gt__()` and :func:`__lt__()`, it can be used with builtins requiring
 
 .. code-block:: python
 
-    >>> semver.max_ver("1.0.0", "2.0.0")
+    >>> str(max(semver.VersionInfo.parse("1.0.0"), semver.VersionInfo.parse("2.0.0")))
     '2.0.0'
-    >>> semver.min_ver("1.0.0", "2.0.0")
+    >>> str(min(semver.VersionInfo.parse("1.0.0"), semver.VersionInfo.parse("2.0.0")))
     '1.0.0'
+
+.. code-block:: python
+
+    >>> max([semver.VersionInfo(0, 1, 0), semver.VersionInfo(0, 2, 0), semver.VersionInfo(0, 1, 3)])
+    VersionInfo(major=0, minor=2, patch=0, prerelease=None, build=None)
+    >>> min([semver.VersionInfo(0, 1, 0), semver.VersionInfo(0, 2, 0), semver.VersionInfo(0, 1, 3)])
+    VersionInfo(major=0, minor=1, patch=0, prerelease=None, build=None)
 
 
 Dealing with Invalid Versions

--- a/test_semver.py
+++ b/test_semver.py
@@ -493,10 +493,6 @@ def test_max_ver_and_min_ver(func, args, expected):
     assert result == expected[func.__name__]
 
 
-def test_should_get_min():
-    assert min_ver("3.4.5", "4.0.2") == "3.4.5"
-
-
 def test_should_get_more_rc1():
     assert compare("1.0.0-rc1", "1.0.0-rc0") == 1
 

--- a/test_semver.py
+++ b/test_semver.py
@@ -78,43 +78,43 @@ def test_fordocstrings(func):
     [
         # no. 1
         (
-                "1.2.3-alpha.1.2+build.11.e0f985a",
-                {
-                    "major": 1,
-                    "minor": 2,
-                    "patch": 3,
-                    "prerelease": "alpha.1.2",
-                    "build": "build.11.e0f985a",
-                },
+            "1.2.3-alpha.1.2+build.11.e0f985a",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "alpha.1.2",
+                "build": "build.11.e0f985a",
+            },
         ),
         # no. 2
         (
-                "1.2.3-alpha-1+build.11.e0f985a",
-                {
-                    "major": 1,
-                    "minor": 2,
-                    "patch": 3,
-                    "prerelease": "alpha-1",
-                    "build": "build.11.e0f985a",
-                },
+            "1.2.3-alpha-1+build.11.e0f985a",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "alpha-1",
+                "build": "build.11.e0f985a",
+            },
         ),
         (
-                "0.1.0-0f",
-                {"major": 0, "minor": 1, "patch": 0, "prerelease": "0f", "build": None},
+            "0.1.0-0f",
+            {"major": 0, "minor": 1, "patch": 0, "prerelease": "0f", "build": None},
         ),
         (
-                "0.0.0-0foo.1",
-                {"major": 0, "minor": 0, "patch": 0, "prerelease": "0foo.1", "build": None},
+            "0.0.0-0foo.1",
+            {"major": 0, "minor": 0, "patch": 0, "prerelease": "0foo.1", "build": None},
         ),
         (
-                "0.0.0-0foo.1+build.1",
-                {
-                    "major": 0,
-                    "minor": 0,
-                    "patch": 0,
-                    "prerelease": "0foo.1",
-                    "build": "build.1",
-                },
+            "0.0.0-0foo.1+build.1",
+            {
+                "major": 0,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": "0foo.1",
+                "build": "build.1",
+            },
         ),
     ],
 )
@@ -128,25 +128,25 @@ def test_should_parse_version(version, expected):
     [
         # no. 1
         (
-                "1.2.3-rc.0+build.0",
-                {
-                    "major": 1,
-                    "minor": 2,
-                    "patch": 3,
-                    "prerelease": "rc.0",
-                    "build": "build.0",
-                },
+            "1.2.3-rc.0+build.0",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "rc.0",
+                "build": "build.0",
+            },
         ),
         # no. 2
         (
-                "1.2.3-rc.0.0+build.0",
-                {
-                    "major": 1,
-                    "minor": 2,
-                    "patch": 3,
-                    "prerelease": "rc.0.0",
-                    "build": "build.0",
-                },
+            "1.2.3-rc.0.0+build.0",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "rc.0.0",
+                "build": "build.0",
+            },
         ),
     ],
 )
@@ -221,7 +221,7 @@ def test_should_match_not_equal(left, right, expected):
     ],
 )
 def test_should_not_raise_value_error_for_expected_match_expression(
-        left, right, expected
+    left, right, expected
 ):
     assert match(left, right) is expected
 
@@ -276,10 +276,10 @@ def test_should_follow_specification_comparison():
     versions = zip(chain[:-1], chain[1:])
     for low_version, high_version in versions:
         assert (
-                compare(low_version, high_version) == -1
+            compare(low_version, high_version) == -1
         ), "%s should be lesser than %s" % (low_version, high_version)
         assert (
-                compare(high_version, low_version) == 1
+            compare(high_version, low_version) == 1
         ), "%s should be higher than %s" % (high_version, low_version)
 
 
@@ -414,68 +414,78 @@ def test_should_ignore_extensions_for_bump():
     "args, expected",
     [
         pytest.param(
-                ("1.2.3", "1.2.4"),
-                {"max_ver": "1.2.4",
-                 "min_ver": "1.2.3"},
-            marks=[pytest.mark.xfail]
+            ("1.2.3", "1.2.4"),
+            {"max_ver": "1.2.4", "min_ver": "1.2.3"},
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                ({"major": 1, "minor": 2, "patch": 3}, {"major": 1, "minor": 2, "patch": 4}),
-                {"max_ver": {"major": 1, "minor": 2, "patch": 4},
-                 "min_ver": {"major": 1, "minor": 2, "patch": 3}},
-            marks=[pytest.mark.xfail]
+            (
+                {"major": 1, "minor": 2, "patch": 3},
+                {"major": 1, "minor": 2, "patch": 4},
+            ),
+            {
+                "max_ver": {"major": 1, "minor": 2, "patch": 4},
+                "min_ver": {"major": 1, "minor": 2, "patch": 3},
+            },
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                ((1, 2, 3), (1, 2, 4)),
-                {"max_ver": (1, 2, 4),
-                 "min_ver": (1, 2, 3)},
-            marks=[pytest.mark.xfail]
+            ((1, 2, 3), (1, 2, 4)),
+            {"max_ver": (1, 2, 4), "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                ("1.2.3", "1.2.4", "1.2.5"),
-                {"max_ver": "1.2.5",
-                 "min_ver": "1.2.3"},
-            marks=[pytest.mark.xfail]
+            ("1.2.3", "1.2.4", "1.2.5"),
+            {"max_ver": "1.2.5", "min_ver": "1.2.3"},
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                ({"major": 1, "minor": 2, "patch": 3}, {"major": 1, "minor": 2, "patch": 4}, {"major": 1, "minor": 2,
-                                                                                              "patch": 5}),
-                {"max_ver": {"major": 1, "minor": 2, "patch": 5},
-                 "min_ver": {"major": 1, "minor": 2, "patch": 3}},
-            marks=[pytest.mark.xfail]
+            (
+                {"major": 1, "minor": 2, "patch": 3},
+                {"major": 1, "minor": 2, "patch": 4},
+                {"major": 1, "minor": 2, "patch": 5},
+            ),
+            {
+                "max_ver": {"major": 1, "minor": 2, "patch": 5},
+                "min_ver": {"major": 1, "minor": 2, "patch": 3},
+            },
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                ((1, 2, 3), (1, 2, 4), (1, 2, 5)),
-                {"max_ver": (1, 2, 5),
-                 "min_ver": (1, 2, 3)},
-            marks=[pytest.mark.xfail]
+            ((1, 2, 3), (1, 2, 4), (1, 2, 5)),
+            {"max_ver": (1, 2, 5), "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                ((1, 2, 3), (1, 2, 4)),
-                {"max_ver": (1, 2, 4),
-                 "min_ver": (1, 2, 3)},
-            marks=[pytest.mark.xfail]
+            ((1, 2, 3), (1, 2, 4)),
+            {"max_ver": (1, 2, 4), "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                (("1.2.3", "1.2.4", "1.2.5"),),
-                {"max_ver": "1.2.5",
-                 "min_ver": "1.2.3"},
-            marks=[pytest.mark.xfail]
+            (("1.2.3", "1.2.4", "1.2.5"),),
+            {"max_ver": "1.2.5", "min_ver": "1.2.3"},
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                (({"major": 1, "minor": 2, "patch": 3}, {"major": 1, "minor": 2, "patch": 4}, {"major": 1, "minor": 2,
-                                                                                               "patch": 5}),),
-                {"max_ver": {"major": 1, "minor": 2, "patch": 5},
-                 "min_ver": {"major": 1, "minor": 2, "patch": 3}},
-            marks=[pytest.mark.xfail]
+            (
+                (
+                    {"major": 1, "minor": 2, "patch": 3},
+                    {"major": 1, "minor": 2, "patch": 4},
+                    {"major": 1, "minor": 2, "patch": 5},
+                ),
+            ),
+            {
+                "max_ver": {"major": 1, "minor": 2, "patch": 5},
+                "min_ver": {"major": 1, "minor": 2, "patch": 3},
+            },
+            marks=[pytest.mark.xfail],
         ),
         pytest.param(
-                (((1, 2, 3), (1, 2, 4), (1, 2, 5)),),
-                {"max_ver": (1, 2, 5),
-                 "min_ver": (1, 2, 3)},
-            marks=[pytest.mark.xfail]
+            (((1, 2, 3), (1, 2, 4), (1, 2, 5)),),
+            {"max_ver": (1, 2, 5), "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail],
         ),
-    ]
+    ],
 )
 def test_max_ver_and_min_ver(func, args, expected):
     result = func(*args)
@@ -623,11 +633,11 @@ def test_should_compare_version_dictionaries():
 @pytest.mark.parametrize(
     "t",  # fmt: off
     (
-            (1, 0, 0),
-            (1, 0),
-            (1,),
-            (1, 0, 0, "pre.2"),
-            (1, 0, 0, "pre.2", "build.4"),
+        (1, 0, 0),
+        (1, 0),
+        (1,),
+        (1, 0, 0, "pre.2"),
+        (1, 0, 0, "pre.2", "build.4"),
     ),  # fmt: on
 )
 def test_should_compare_version_tuples(t):
@@ -652,11 +662,11 @@ def test_should_compare_version_tuples(t):
 @pytest.mark.parametrize(
     "lst",  # fmt: off
     (
-            [1, 0, 0],
-            [1, 0],
-            [1],
-            [1, 0, 0, "pre.2"],
-            [1, 0, 0, "pre.2", "build.4"],
+        [1, 0, 0],
+        [1, 0],
+        [1],
+        [1, 0, 0, "pre.2"],
+        [1, 0, 0, "pre.2", "build.4"],
     ),  # fmt: on
 )
 def test_should_compare_version_list(lst):
@@ -681,11 +691,11 @@ def test_should_compare_version_list(lst):
 @pytest.mark.parametrize(
     "s",  # fmt: off
     (
-            "1.0.0",
-            # "1.0",
-            # "1",
-            "1.0.0-pre.2",
-            "1.0.0-pre.2+build.4",
+        "1.0.0",
+        # "1.0",
+        # "1",
+        "1.0.0-pre.2",
+        "1.0.0-pre.2+build.4",
     ),  # fmt: on
 )
 def test_should_compare_version_string(s):
@@ -872,7 +882,7 @@ def test_version_info_should_be_accessed_with_index(version, index, expected):
     ],
 )
 def test_version_info_should_be_accessed_with_slice_object(
-        version, slice_object, expected
+    version, slice_object, expected
 ):
     version_info = VersionInfo.parse(version)
     assert version_info[slice_object] == expected
@@ -922,8 +932,8 @@ def test_version_info_should_throw_index_error_when_negative_index(version, inde
         (["bump", "minor", "1.2.3"], Namespace(bump="minor", version="1.2.3")),
         (["bump", "patch", "1.2.3"], Namespace(bump="patch", version="1.2.3")),
         (
-                ["bump", "prerelease", "1.2.3"],
-                Namespace(bump="prerelease", version="1.2.3"),
+            ["bump", "prerelease", "1.2.3"],
+            Namespace(bump="prerelease", version="1.2.3"),
         ),
         (["bump", "build", "1.2.3"], Namespace(bump="build", version="1.2.3")),
         # ---
@@ -948,49 +958,49 @@ def test_should_parse_cli_arguments(cli, expected):
         (cmd_bump, Namespace(bump="minor", version="1.2.3"), does_not_raise("1.3.0")),
         (cmd_bump, Namespace(bump="patch", version="1.2.3"), does_not_raise("1.2.4")),
         (
-                cmd_bump,
-                Namespace(bump="prerelease", version="1.2.3-rc1"),
-                does_not_raise("1.2.3-rc2"),
+            cmd_bump,
+            Namespace(bump="prerelease", version="1.2.3-rc1"),
+            does_not_raise("1.2.3-rc2"),
         ),
         (
-                cmd_bump,
-                Namespace(bump="build", version="1.2.3+build.13"),
-                does_not_raise("1.2.3+build.14"),
+            cmd_bump,
+            Namespace(bump="build", version="1.2.3+build.13"),
+            does_not_raise("1.2.3+build.14"),
         ),
         # compare subcommand
         (
-                cmd_compare,
-                Namespace(version1="1.2.3", version2="2.1.3"),
-                does_not_raise("-1"),
+            cmd_compare,
+            Namespace(version1="1.2.3", version2="2.1.3"),
+            does_not_raise("-1"),
         ),
         (
-                cmd_compare,
-                Namespace(version1="1.2.3", version2="1.2.3"),
-                does_not_raise("0"),
+            cmd_compare,
+            Namespace(version1="1.2.3", version2="1.2.3"),
+            does_not_raise("0"),
         ),
         (
-                cmd_compare,
-                Namespace(version1="2.4.0", version2="2.1.3"),
-                does_not_raise("1"),
+            cmd_compare,
+            Namespace(version1="2.4.0", version2="2.1.3"),
+            does_not_raise("1"),
         ),
         # check subcommand
         (cmd_check, Namespace(version="1.2.3"), does_not_raise(None)),
         (cmd_check, Namespace(version="1.2"), pytest.raises(ValueError)),
         # nextver subcommand
         (
-                cmd_nextver,
-                Namespace(version="1.2.3", part="major"),
-                does_not_raise("2.0.0"),
+            cmd_nextver,
+            Namespace(version="1.2.3", part="major"),
+            does_not_raise("2.0.0"),
         ),
         (
-                cmd_nextver,
-                Namespace(version="1.2", part="major"),
-                pytest.raises(ValueError),
+            cmd_nextver,
+            Namespace(version="1.2", part="major"),
+            pytest.raises(ValueError),
         ),
         (
-                cmd_nextver,
-                Namespace(version="1.2.3", part="nope"),
-                pytest.raises(ValueError),
+            cmd_nextver,
+            Namespace(version="1.2.3", part="nope"),
+            pytest.raises(ValueError),
         ),
     ],
 )
@@ -1041,9 +1051,9 @@ def test_should_process_check_iscalled_with_valid_version(capsys):
         ("3.4.5", dict(major=2, minor=5, patch=10), "2.5.10"),
         ("3.4.5", dict(major=2, minor=5, patch=10, prerelease="rc1"), "2.5.10-rc1"),
         (
-                "3.4.5",
-                dict(major=2, minor=5, patch=10, prerelease="rc1", build="b1"),
-                "2.5.10-rc1+b1",
+            "3.4.5",
+            dict(major=2, minor=5, patch=10, prerelease="rc1", build="b1"),
+            "2.5.10-rc1+b1",
         ),
         ("3.4.5-alpha.1.2", dict(major=2), "2.4.5-alpha.1.2"),
         ("3.4.5-alpha.1.2", dict(build="x1"), "3.4.5-alpha.1.2+x1"),
@@ -1102,7 +1112,7 @@ def test_should_versioninfo_isvalid():
 )
 def test_should_raise_deprecation_warnings(func, args, kwargs):
     with pytest.warns(
-            DeprecationWarning, match=r"Function 'semver.[_a-zA-Z]+' is deprecated."
+        DeprecationWarning, match=r"Function 'semver.[_a-zA-Z]+' is deprecated."
     ) as record:
         func(*args, **kwargs)
         if not record:
@@ -1161,28 +1171,28 @@ def test_next_version_with_versioninfo(version, part, expected):
     "version, expected",
     [
         (
-                VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None),
-                "VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None)",
+            VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None),
+            "VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None)",
         ),
         (
-                VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build=None),
-                "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build=None)",
+            VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build=None),
+            "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build=None)",
         ),
         (
-                VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build=None),
-                "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build=None)",
+            VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build=None),
+            "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build=None)",
         ),
         (
-                VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build="b.1"),
-                "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build='b.1')",
+            VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build="b.1"),
+            "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build='b.1')",
         ),
         (
-                VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="b.1"),
-                "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='b.1')",
+            VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="b.1"),
+            "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='b.1')",
         ),
         (
-                VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="build.1"),
-                "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='build.1')",
+            VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="build.1"),
+            "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='build.1')",
         ),
     ],
 )

--- a/test_semver.py
+++ b/test_semver.py
@@ -78,43 +78,43 @@ def test_fordocstrings(func):
     [
         # no. 1
         (
-            "1.2.3-alpha.1.2+build.11.e0f985a",
-            {
-                "major": 1,
-                "minor": 2,
-                "patch": 3,
-                "prerelease": "alpha.1.2",
-                "build": "build.11.e0f985a",
-            },
+                "1.2.3-alpha.1.2+build.11.e0f985a",
+                {
+                    "major": 1,
+                    "minor": 2,
+                    "patch": 3,
+                    "prerelease": "alpha.1.2",
+                    "build": "build.11.e0f985a",
+                },
         ),
         # no. 2
         (
-            "1.2.3-alpha-1+build.11.e0f985a",
-            {
-                "major": 1,
-                "minor": 2,
-                "patch": 3,
-                "prerelease": "alpha-1",
-                "build": "build.11.e0f985a",
-            },
+                "1.2.3-alpha-1+build.11.e0f985a",
+                {
+                    "major": 1,
+                    "minor": 2,
+                    "patch": 3,
+                    "prerelease": "alpha-1",
+                    "build": "build.11.e0f985a",
+                },
         ),
         (
-            "0.1.0-0f",
-            {"major": 0, "minor": 1, "patch": 0, "prerelease": "0f", "build": None},
+                "0.1.0-0f",
+                {"major": 0, "minor": 1, "patch": 0, "prerelease": "0f", "build": None},
         ),
         (
-            "0.0.0-0foo.1",
-            {"major": 0, "minor": 0, "patch": 0, "prerelease": "0foo.1", "build": None},
+                "0.0.0-0foo.1",
+                {"major": 0, "minor": 0, "patch": 0, "prerelease": "0foo.1", "build": None},
         ),
         (
-            "0.0.0-0foo.1+build.1",
-            {
-                "major": 0,
-                "minor": 0,
-                "patch": 0,
-                "prerelease": "0foo.1",
-                "build": "build.1",
-            },
+                "0.0.0-0foo.1+build.1",
+                {
+                    "major": 0,
+                    "minor": 0,
+                    "patch": 0,
+                    "prerelease": "0foo.1",
+                    "build": "build.1",
+                },
         ),
     ],
 )
@@ -128,25 +128,25 @@ def test_should_parse_version(version, expected):
     [
         # no. 1
         (
-            "1.2.3-rc.0+build.0",
-            {
-                "major": 1,
-                "minor": 2,
-                "patch": 3,
-                "prerelease": "rc.0",
-                "build": "build.0",
-            },
+                "1.2.3-rc.0+build.0",
+                {
+                    "major": 1,
+                    "minor": 2,
+                    "patch": 3,
+                    "prerelease": "rc.0",
+                    "build": "build.0",
+                },
         ),
         # no. 2
         (
-            "1.2.3-rc.0.0+build.0",
-            {
-                "major": 1,
-                "minor": 2,
-                "patch": 3,
-                "prerelease": "rc.0.0",
-                "build": "build.0",
-            },
+                "1.2.3-rc.0.0+build.0",
+                {
+                    "major": 1,
+                    "minor": 2,
+                    "patch": 3,
+                    "prerelease": "rc.0.0",
+                    "build": "build.0",
+                },
         ),
     ],
 )
@@ -221,7 +221,7 @@ def test_should_match_not_equal(left, right, expected):
     ],
 )
 def test_should_not_raise_value_error_for_expected_match_expression(
-    left, right, expected
+        left, right, expected
 ):
     assert match(left, right) is expected
 
@@ -276,10 +276,10 @@ def test_should_follow_specification_comparison():
     versions = zip(chain[:-1], chain[1:])
     for low_version, high_version in versions:
         assert (
-            compare(low_version, high_version) == -1
+                compare(low_version, high_version) == -1
         ), "%s should be lesser than %s" % (low_version, high_version)
         assert (
-            compare(high_version, low_version) == 1
+                compare(high_version, low_version) == 1
         ), "%s should be higher than %s" % (high_version, low_version)
 
 
@@ -409,20 +409,82 @@ def test_should_ignore_extensions_for_bump():
     assert bump_patch("3.4.5-rc1+build4") == "3.4.6"
 
 
-def test_should_get_max():
-    assert max_ver("3.4.5", "4.0.2") == "4.0.2"
-
-
-def test_should_get_max_same():
-    assert max_ver("3.4.5", "3.4.5") == "3.4.5"
+@pytest.mark.parametrize("func", (max_ver, min_ver))
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        pytest.param(
+                ("1.2.3", "1.2.4"),
+                {"max_ver": "1.2.4",
+                 "min_ver": "1.2.3"},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                ({"major": 1, "minor": 2, "patch": 3}, {"major": 1, "minor": 2, "patch": 4}),
+                {"max_ver": {"major": 1, "minor": 2, "patch": 4},
+                 "min_ver": {"major": 1, "minor": 2, "patch": 3}},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                ((1, 2, 3), (1, 2, 4)),
+                {"max_ver": (1, 2, 4),
+                 "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                ("1.2.3", "1.2.4", "1.2.5"),
+                {"max_ver": "1.2.5",
+                 "min_ver": "1.2.3"},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                ({"major": 1, "minor": 2, "patch": 3}, {"major": 1, "minor": 2, "patch": 4}, {"major": 1, "minor": 2,
+                                                                                              "patch": 5}),
+                {"max_ver": {"major": 1, "minor": 2, "patch": 5},
+                 "min_ver": {"major": 1, "minor": 2, "patch": 3}},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                ((1, 2, 3), (1, 2, 4), (1, 2, 5)),
+                {"max_ver": (1, 2, 5),
+                 "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                ((1, 2, 3), (1, 2, 4)),
+                {"max_ver": (1, 2, 4),
+                 "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                (("1.2.3", "1.2.4", "1.2.5"),),
+                {"max_ver": "1.2.5",
+                 "min_ver": "1.2.3"},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                (({"major": 1, "minor": 2, "patch": 3}, {"major": 1, "minor": 2, "patch": 4}, {"major": 1, "minor": 2,
+                                                                                               "patch": 5}),),
+                {"max_ver": {"major": 1, "minor": 2, "patch": 5},
+                 "min_ver": {"major": 1, "minor": 2, "patch": 3}},
+            marks=[pytest.mark.xfail]
+        ),
+        pytest.param(
+                (((1, 2, 3), (1, 2, 4), (1, 2, 5)),),
+                {"max_ver": (1, 2, 5),
+                 "min_ver": (1, 2, 3)},
+            marks=[pytest.mark.xfail]
+        ),
+    ]
+)
+def test_max_ver_and_min_ver(func, args, expected):
+    result = func(*args)
+    assert type(result) == type(expected)
+    assert result == expected[func.__name__]
 
 
 def test_should_get_min():
     assert min_ver("3.4.5", "4.0.2") == "3.4.5"
-
-
-def test_should_get_min_same():
-    assert min_ver("3.4.5", "3.4.5") == "3.4.5"
 
 
 def test_should_get_more_rc1():
@@ -561,11 +623,11 @@ def test_should_compare_version_dictionaries():
 @pytest.mark.parametrize(
     "t",  # fmt: off
     (
-        (1, 0, 0),
-        (1, 0),
-        (1,),
-        (1, 0, 0, "pre.2"),
-        (1, 0, 0, "pre.2", "build.4"),
+            (1, 0, 0),
+            (1, 0),
+            (1,),
+            (1, 0, 0, "pre.2"),
+            (1, 0, 0, "pre.2", "build.4"),
     ),  # fmt: on
 )
 def test_should_compare_version_tuples(t):
@@ -590,11 +652,11 @@ def test_should_compare_version_tuples(t):
 @pytest.mark.parametrize(
     "lst",  # fmt: off
     (
-        [1, 0, 0],
-        [1, 0],
-        [1],
-        [1, 0, 0, "pre.2"],
-        [1, 0, 0, "pre.2", "build.4"],
+            [1, 0, 0],
+            [1, 0],
+            [1],
+            [1, 0, 0, "pre.2"],
+            [1, 0, 0, "pre.2", "build.4"],
     ),  # fmt: on
 )
 def test_should_compare_version_list(lst):
@@ -619,11 +681,11 @@ def test_should_compare_version_list(lst):
 @pytest.mark.parametrize(
     "s",  # fmt: off
     (
-        "1.0.0",
-        # "1.0",
-        # "1",
-        "1.0.0-pre.2",
-        "1.0.0-pre.2+build.4",
+            "1.0.0",
+            # "1.0",
+            # "1",
+            "1.0.0-pre.2",
+            "1.0.0-pre.2+build.4",
     ),  # fmt: on
 )
 def test_should_compare_version_string(s):
@@ -810,7 +872,7 @@ def test_version_info_should_be_accessed_with_index(version, index, expected):
     ],
 )
 def test_version_info_should_be_accessed_with_slice_object(
-    version, slice_object, expected
+        version, slice_object, expected
 ):
     version_info = VersionInfo.parse(version)
     assert version_info[slice_object] == expected
@@ -860,8 +922,8 @@ def test_version_info_should_throw_index_error_when_negative_index(version, inde
         (["bump", "minor", "1.2.3"], Namespace(bump="minor", version="1.2.3")),
         (["bump", "patch", "1.2.3"], Namespace(bump="patch", version="1.2.3")),
         (
-            ["bump", "prerelease", "1.2.3"],
-            Namespace(bump="prerelease", version="1.2.3"),
+                ["bump", "prerelease", "1.2.3"],
+                Namespace(bump="prerelease", version="1.2.3"),
         ),
         (["bump", "build", "1.2.3"], Namespace(bump="build", version="1.2.3")),
         # ---
@@ -886,49 +948,49 @@ def test_should_parse_cli_arguments(cli, expected):
         (cmd_bump, Namespace(bump="minor", version="1.2.3"), does_not_raise("1.3.0")),
         (cmd_bump, Namespace(bump="patch", version="1.2.3"), does_not_raise("1.2.4")),
         (
-            cmd_bump,
-            Namespace(bump="prerelease", version="1.2.3-rc1"),
-            does_not_raise("1.2.3-rc2"),
+                cmd_bump,
+                Namespace(bump="prerelease", version="1.2.3-rc1"),
+                does_not_raise("1.2.3-rc2"),
         ),
         (
-            cmd_bump,
-            Namespace(bump="build", version="1.2.3+build.13"),
-            does_not_raise("1.2.3+build.14"),
+                cmd_bump,
+                Namespace(bump="build", version="1.2.3+build.13"),
+                does_not_raise("1.2.3+build.14"),
         ),
         # compare subcommand
         (
-            cmd_compare,
-            Namespace(version1="1.2.3", version2="2.1.3"),
-            does_not_raise("-1"),
+                cmd_compare,
+                Namespace(version1="1.2.3", version2="2.1.3"),
+                does_not_raise("-1"),
         ),
         (
-            cmd_compare,
-            Namespace(version1="1.2.3", version2="1.2.3"),
-            does_not_raise("0"),
+                cmd_compare,
+                Namespace(version1="1.2.3", version2="1.2.3"),
+                does_not_raise("0"),
         ),
         (
-            cmd_compare,
-            Namespace(version1="2.4.0", version2="2.1.3"),
-            does_not_raise("1"),
+                cmd_compare,
+                Namespace(version1="2.4.0", version2="2.1.3"),
+                does_not_raise("1"),
         ),
         # check subcommand
         (cmd_check, Namespace(version="1.2.3"), does_not_raise(None)),
         (cmd_check, Namespace(version="1.2"), pytest.raises(ValueError)),
         # nextver subcommand
         (
-            cmd_nextver,
-            Namespace(version="1.2.3", part="major"),
-            does_not_raise("2.0.0"),
+                cmd_nextver,
+                Namespace(version="1.2.3", part="major"),
+                does_not_raise("2.0.0"),
         ),
         (
-            cmd_nextver,
-            Namespace(version="1.2", part="major"),
-            pytest.raises(ValueError),
+                cmd_nextver,
+                Namespace(version="1.2", part="major"),
+                pytest.raises(ValueError),
         ),
         (
-            cmd_nextver,
-            Namespace(version="1.2.3", part="nope"),
-            pytest.raises(ValueError),
+                cmd_nextver,
+                Namespace(version="1.2.3", part="nope"),
+                pytest.raises(ValueError),
         ),
     ],
 )
@@ -979,9 +1041,9 @@ def test_should_process_check_iscalled_with_valid_version(capsys):
         ("3.4.5", dict(major=2, minor=5, patch=10), "2.5.10"),
         ("3.4.5", dict(major=2, minor=5, patch=10, prerelease="rc1"), "2.5.10-rc1"),
         (
-            "3.4.5",
-            dict(major=2, minor=5, patch=10, prerelease="rc1", build="b1"),
-            "2.5.10-rc1+b1",
+                "3.4.5",
+                dict(major=2, minor=5, patch=10, prerelease="rc1", build="b1"),
+                "2.5.10-rc1+b1",
         ),
         ("3.4.5-alpha.1.2", dict(major=2), "2.4.5-alpha.1.2"),
         ("3.4.5-alpha.1.2", dict(build="x1"), "3.4.5-alpha.1.2+x1"),
@@ -1040,7 +1102,7 @@ def test_should_versioninfo_isvalid():
 )
 def test_should_raise_deprecation_warnings(func, args, kwargs):
     with pytest.warns(
-        DeprecationWarning, match=r"Function 'semver.[_a-zA-Z]+' is deprecated."
+            DeprecationWarning, match=r"Function 'semver.[_a-zA-Z]+' is deprecated."
     ) as record:
         func(*args, **kwargs)
         if not record:
@@ -1099,28 +1161,28 @@ def test_next_version_with_versioninfo(version, part, expected):
     "version, expected",
     [
         (
-            VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None),
-            "VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None)",
+                VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None),
+                "VersionInfo(major=1, minor=2, patch=3, prerelease=None, build=None)",
         ),
         (
-            VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build=None),
-            "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build=None)",
+                VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build=None),
+                "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build=None)",
         ),
         (
-            VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build=None),
-            "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build=None)",
+                VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build=None),
+                "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build=None)",
         ),
         (
-            VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build="b.1"),
-            "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build='b.1')",
+                VersionInfo(major=1, minor=2, patch=3, prerelease="dev.1", build="b.1"),
+                "VersionInfo(major=1, minor=2, patch=3, prerelease='dev.1', build='b.1')",
         ),
         (
-            VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="b.1"),
-            "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='b.1')",
+                VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="b.1"),
+                "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='b.1')",
         ),
         (
-            VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="build.1"),
-            "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='build.1')",
+                VersionInfo(major=1, minor=2, patch=3, prerelease="r.1", build="build.1"),
+                "VersionInfo(major=1, minor=2, patch=3, prerelease='r.1', build='build.1')",
         ),
     ],
 )


### PR DESCRIPTION
This allows the use of an arbitrary number of args or an iterable for max_ver and min_ver.
All the args must of a homogeneous type (all the same). This fixes #160 