### PR TITLE
Fix #274:  String Types Py2 vs. Py3 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ Bug Fixes
 ---------
 
 * :gh:`276` (:pr:`277`): VersionInfo.parse should be a class method
+* :gh:`274` (:pr:`275`): Py2 vs. Py3 incompatibility TypeError
 
 
 Additions

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -28,6 +28,7 @@ Significant contributors
 * Carles Barrobés <carles@barrobes.com>
 * Craig Blaszczyk <masterjakul@gmail.com>
 * Damien Nadé <anvil@users.noreply.github.com>
+* Eli Bishop <eli-darkly@users.noreply.github.com>
 * George Sakkis <gsakkis@users.noreply.github.com>
 * Jan Pieter Waagmeester <jieter@jieter.nl>
 * Jelo Agnasin <jelo@icannhas.com>

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -45,10 +45,17 @@ creating a version:
 
 A :class:`semver.VersionInfo` instance can be created in different ways:
 
-* From a string::
+* From a string (a Unicode string in Python 2)::
 
     >>> semver.VersionInfo.parse("3.4.5-pre.2+build.4")
     VersionInfo(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
+    >>> semver.VersionInfo.parse(u"5.3.1")
+    VersionInfo(major=5, minor=3, patch=1, prerelease=None, build=None)
+
+* From a byte string::
+
+    >>> semver.VersionInfo.parse(b"2.3.4")
+    VersionInfo(major=2, minor=3, patch=4, prerelease=None, build=None)
 
 * From individual parts by a dictionary::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ addopts =
 
 [flake8]
 max-line-length = 88
+ignore = F821,W503
 exclude =
     .env,
     .eggs,

--- a/test_typeerror-274.py
+++ b/test_typeerror-274.py
@@ -1,0 +1,102 @@
+import pytest
+import sys
+
+import semver
+
+
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+
+
+def ensure_binary(s, encoding="utf-8", errors="strict"):
+    """Coerce **s** to six.binary_type.
+
+    For Python 2:
+      - `unicode` -> encoded to `str`
+      - `str` -> `str`
+
+    For Python 3:
+      - `str` -> encoded to `bytes`
+      - `bytes` -> `bytes`
+    """
+    if isinstance(s, semver.text_type):
+        return s.encode(encoding, errors)
+    elif isinstance(s, semver.binary_type):
+        return s
+    else:
+        raise TypeError("not expecting type '%s'" % type(s))
+
+
+def test_should_work_with_string_and_unicode():
+    result = semver.compare(semver.u("1.1.0"), semver.b("1.2.2"))
+    assert result == -1
+    result = semver.compare(semver.b("1.1.0"), semver.u("1.2.2"))
+    assert result == -1
+
+
+class TestEnsure:
+    # From six project
+    # grinning face emoji
+    UNICODE_EMOJI = semver.u("\U0001F600")
+    BINARY_EMOJI = b"\xf0\x9f\x98\x80"
+
+    def test_ensure_binary_raise_type_error(self):
+        with pytest.raises(TypeError):
+            semver.ensure_str(8)
+
+    def test_errors_and_encoding(self):
+        ensure_binary(self.UNICODE_EMOJI, encoding="latin-1", errors="ignore")
+        with pytest.raises(UnicodeEncodeError):
+            ensure_binary(self.UNICODE_EMOJI, encoding="latin-1", errors="strict")
+
+    def test_ensure_binary_raise(self):
+        converted_unicode = ensure_binary(
+            self.UNICODE_EMOJI, encoding="utf-8", errors="strict"
+        )
+        converted_binary = ensure_binary(
+            self.BINARY_EMOJI, encoding="utf-8", errors="strict"
+        )
+        if semver.PY2:
+            # PY2: unicode -> str
+            assert converted_unicode == self.BINARY_EMOJI and isinstance(
+                converted_unicode, str
+            )
+            # PY2: str -> str
+            assert converted_binary == self.BINARY_EMOJI and isinstance(
+                converted_binary, str
+            )
+        else:
+            # PY3: str -> bytes
+            assert converted_unicode == self.BINARY_EMOJI and isinstance(
+                converted_unicode, bytes
+            )
+            # PY3: bytes -> bytes
+            assert converted_binary == self.BINARY_EMOJI and isinstance(
+                converted_binary, bytes
+            )
+
+    def test_ensure_str(self):
+        converted_unicode = semver.ensure_str(
+            self.UNICODE_EMOJI, encoding="utf-8", errors="strict"
+        )
+        converted_binary = semver.ensure_str(
+            self.BINARY_EMOJI, encoding="utf-8", errors="strict"
+        )
+        if PY2:
+            # PY2: unicode -> str
+            assert converted_unicode == self.BINARY_EMOJI and isinstance(
+                converted_unicode, str
+            )
+            # PY2: str -> str
+            assert converted_binary == self.BINARY_EMOJI and isinstance(
+                converted_binary, str
+            )
+        else:
+            # PY3: str -> str
+            assert converted_unicode == self.UNICODE_EMOJI and isinstance(
+                converted_unicode, str
+            )
+            # PY3: bytes -> str
+            assert converted_binary == self.UNICODE_EMOJI and isinstance(
+                converted_unicode, str
+            )


### PR DESCRIPTION
This fixes #274 and contains:

fixes problems between different string types. In Python2 `str` vs. `unicode` and in Python3 `str` vs. `bytes`.

---

@eli-darkly I've tried to recycle some code from the six project. Maybe there is an easier way, maybe we can improve some ugly code. Would you like to have a look at? Thank you! :heart: 
