### PR TITLE
Ensure equal versions have equal hashes

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -452,6 +452,30 @@ functions that leverage this capability; builtins including, but not limited to:
 (for examples, see :ref:`sec_max_min`) and :func:`sorted`.
 
 
+Version Equality
+----------------
+
+Note that when comparing two versions, the ``build`` part is ignored::
+
+    >>> v = semver.VersionInfo.parse("1.2.3-rc4+1e4664d")
+    >>> v == "1.2.3-rc4+dedbeef"
+    True
+
+This also applies when a :class:`semver.VersionInfo` is a member of a set, or a
+dictionary key::
+
+    >>> d = {}
+    >>> v1 = semver.VersionInfo.parse("1.2.3-rc4+1e4664d")
+    >>> v2 = semver.VersionInfo.parse("1.2.3-rc4+dedbeef")
+    >>> d[v1] = 1
+    >>> d[v2]
+    1
+    >>> s = set()
+    >>> s.add(v1)
+    >>> v2 in s
+    True
+
+
 
 Comparing Versions through an Expression
 ----------------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -453,7 +453,7 @@ functions that leverage this capability; builtins including, but not limited to:
 
 
 Determining Version Equality
-----------------
+----------------------------
 
 Version equality means for semver, that major, minor, patch, and prerelease
 parts are equal in both versions you compare. The build part is ignored.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -452,10 +452,12 @@ functions that leverage this capability; builtins including, but not limited to:
 (for examples, see :ref:`sec_max_min`) and :func:`sorted`.
 
 
-Version Equality
+Determining Version Equality
 ----------------
 
-Note that when comparing two versions, the ``build`` part is ignored::
+Version equality means for semver, that major, minor, patch, and prerelease
+parts are equal in both versions you compare. The build part is ignored.
+For example::
 
     >>> v = semver.VersionInfo.parse("1.2.3-rc4+1e4664d")
     >>> v == "1.2.3-rc4+dedbeef"

--- a/semver.py
+++ b/semver.py
@@ -575,7 +575,7 @@ build='build.10')
         return version
 
     def __hash__(self):
-        return hash(self.to_tuple())
+        return hash(self.to_tuple()[:4])
 
     def finalize_version(self):
         """

--- a/test_semver.py
+++ b/test_semver.py
@@ -679,6 +679,20 @@ def test_parse_version_info_str_hash():
     d[v] = ""  # to ensure that VersionInfo are hashable
 
 
+def test_equal_versions_have_equal_hashes():
+    v1 = parse_version_info("1.2.3-alpha.1.2+build.11.e0f985a")
+    v2 = parse_version_info("1.2.3-alpha.1.2+build.22.a589f0e")
+    assert v1 == v2
+    assert hash(v1) == hash(v2)
+    d = {}
+    d[v1] = 1
+    d[v2] = 2
+    assert d[v1] == 2
+    s = set()
+    s.add(v1)
+    assert v2 in s
+
+
 def test_parse_method_for_version_info():
     s_version = "1.2.3-alpha.1.2+build.11.e0f985a"
     v = VersionInfo.parse(s_version)


### PR DESCRIPTION
Per [the python datamodel](https://docs.python.org/3/reference/datamodel.html#object.__hash__), `a == b` implies `hash(a) == hash(b)`. The current implementation of `VersionInfo.__hash__` includes the build, which isn't used for equality.