### PR TITLE
Prepare 2.11.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,11 +7,11 @@ All notable changes to this code base will be documented in this file,
 in every released version.
 
 
-Version 2.11.0 (WIP)
-====================
+Version 2.11.0
+==============
 
-:Released: n/a
-:Maintainer: n/a
+:Released: 2020-10-17
+:Maintainer: Tom Schraitle
 
 Features
 --------
@@ -23,6 +23,7 @@ Bug Fixes
 ---------
 
 * :gh:`276` (:pr:`277`): VersionInfo.parse should be a class method
+   Also add authors and update changelog in :gh:`286`
 * :gh:`274` (:pr:`275`): Py2 vs. Py3 incompatibility TypeError
 
 
@@ -123,7 +124,7 @@ Additions
 
 
 Deprecations
---------
+------------
 * :gh:`225` (:pr:`229`): Output a DeprecationWarning for the following functions:
 
   - ``semver.parse``

--- a/semver.py
+++ b/semver.py
@@ -14,7 +14,7 @@ PY2 = sys.version_info[0] == 2
 PY3 = sys.version_info[0] == 3
 
 
-__version__ = "2.10.2"
+__version__ = "2.11.0"
 __author__ = "Kostiantyn Rybnikov"
 __author_email__ = "k-bx@k-bx.com"
 __maintainer__ = ["Sebastien Celles", "Tom Schraitle"]
@@ -697,6 +697,10 @@ build='build.10')
         :return: a :class:`VersionInfo` instance
         :raises: :class:`ValueError`
         :rtype: :class:`VersionInfo`
+
+        .. versionchanged:: 2.11.0
+           Changed method from static to classmethod to
+           allow subclasses.
 
         >>> semver.VersionInfo.parse('3.4.5-pre.2+build.4')
         VersionInfo(major=3, minor=4, patch=5, \


### PR DESCRIPTION
This fixes #288 and contains:

* #274 / #275 String Types Py2 vs. Py3 compatibility
* #277 Turn VersionInfo.parse into classmethod to allow subclasses
* #286 Add author and update changelog for #276/#277