### PR TITLE
Support latest Python version for semver2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,13 @@ matrix:
     dist: xenial
     env: TOXENV=py37
 
+  - python: "3.8"
+    dist: xenial
+    env: TOXENV=py38
+
+  - python: "3.9-dev"
+    dist: bionic
+    env: TOXENV=py39
+
   - python: "pypy"
     env: TOXENV=pypy

--- a/README.rst
+++ b/README.rst
@@ -12,18 +12,18 @@ A Python module for `semantic versioning`_. Simplifies comparing versions.
 .. warning::
 
    As anything comes to an end, this project will focus on Python 3.x only.
-   New features and bugfixes will be integrated into the 3.x.y branch only.
+   New features and bugfixes will be integrated into semver3 only.
 
    Major version 3 of semver will contain some incompatible changes:
 
-   * removes support for Python 2.7 and 3.3
+   * removes support for Python 2.7, 3.3, 3.4, and 3.5.
    * removes deprecated functions.
 
-   The last version of semver which supports Python 2.7 and 3.4 will be
-   2.10.x. However, keep in mind, version 2.10.x is frozen: no new
+   The last version of semver which supports Python 2.7 and 3.5 will be
+   2.x.y. However, keep in mind, this version is frozen: no new
    features nor backports will be integrated.
 
-   We recommend to upgrade your workflow to Python 3.x to gain support,
+   We recommend to upgrade your workflow to Python >=3.6 to gain support,
    bugfixes, and new features.
 
 The module follows the ``MAJOR.MINOR.PATCH`` style:

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     flake8
-    py{27,34,35,36,37}
+    py{27,34,35,36,37,38,39}
     pypy
 
 [testenv]
-description = Run test suite
+description = Run test suite for {basepython}
 whitelist_externals = make
 commands = pytest {posargs:}
 deps =


### PR DESCRIPTION
This PR contains:

* Update README.rst and NOT mention specific versions. Use "2.x.y" as versions can change.
* Support Python 3.8/3.9 for semver2