### PR TITLE
Doc: Disable sphinx-argparse

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 # requirements file for documentation
 sphinx
-sphinx-argparse
+# sphinx-argparse
 sphinx-autodoc-typehints


### PR DESCRIPTION
This should (hopefully) fix #297 as it disables `sphinx-argparse`. It's not needed anymore.