### PR TITLE
Tox: skip installation for changelog target

### DIFF
--- a/changelog.d/313.trivial.rst
+++ b/changelog.d/313.trivial.rst
@@ -1,0 +1,3 @@
+Correct :file:`tox.ini` for ``changelog`` entry to skip
+installation for semver. This should speed up the execution
+of towncrier.

--- a/tox.ini
+++ b/tox.ini
@@ -103,6 +103,7 @@ commands =
 [testenv:changelog]
 description = Run towncrier to check, build, or create the CHANGELOG.rst
 basepython = python3
+skip_install = true
 deps =
     git+https://github.com/twisted/towncrier.git
 commands =


### PR DESCRIPTION
This PR contains only a single change: add `skip_install = true`. This speeds up the execution of towncrier.

As we only need to install towncrier, it is not necessary to install semver too. Therefor, we skip the installation of semver.