### PR TITLE
Improve usage section

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,59 @@ in our repository.
 Version 3.0.0-dev.2
 ===================
 
+:Released: 2020-11-04
+:Maintainer:
+
+
+Improved Documentation
+----------------------
+
+* :gh:`312`: Rework "Usage" section.
+
+  * Mention the rename of :class:`~semver.version.VersionInfo` to
+    :class:`~semver.version.Version` class
+  * Remove semver. prefix in doctests to make examples shorter
+  * Correct some references to dunder methods like
+    :func:`~.semver.version.Version.__getitem__`,
+    :func:`~.semver.version.Version.__gt__` etc.
+  * Remove inconsistencies and mention module level function as
+    deprecated and discouraged from using
+  * Make empty :py:func:`super` call in :file:`semverwithvprefix.py` example
+
+
+
+----
+
+
+Version 3.0.0-dev.2
+===================
+
+:Released: 2020-11-04
+:Maintainer:
+
+
+Improved Documentation
+----------------------
+
+* :gh:`312`: Rework "Usage" section.
+
+  * Mention the rename of :class:`~semver.version.VersionInfo` to
+    :class:`~semver.version.Version` class
+  * Remove semver. prefix in doctests to make examples shorter
+  * Correct some references to dunder methods like :func:`__getitem__`,
+    :func:`__gt__` etc.
+  * Remove inconsistencies and mention module level function as
+    deprecated and discouraged from using
+  * Make empty :py:func:`super` call in :file:`semverwithvprefix.py` example
+
+
+
+----
+
+
+Version 3.0.0-dev.2
+===================
+
 :Released: 2020-11-01
 :Maintainer: Tom Schraitle
 

--- a/changelog.d/213.improvement.rst
+++ b/changelog.d/213.improvement.rst
@@ -1,1 +1,0 @@
-Add typing information

--- a/changelog.d/312.doc.rst
+++ b/changelog.d/312.doc.rst
@@ -1,0 +1,11 @@
+Rework "Usage" section.
+
+* Mention the rename of :class:`~semver.version.VersionInfo` to
+  :class:`~semver.version.Version` class
+* Remove semver. prefix in doctests to make examples shorter
+* Correct some references to dunder methods like
+  :func:`~.semver.version.Version.__getitem__`,
+  :func:`~.semver.version.Version.__gt__` etc.
+* Remove inconsistencies and mention module level function as
+  deprecated and discouraged from using
+* Make empty :py:func:`super` call in :file:`semverwithvprefix.py` example

--- a/docs/semverwithvprefix.py
+++ b/docs/semverwithvprefix.py
@@ -7,15 +7,13 @@ class SemVerWithVPrefix(Version):
     """
 
     @classmethod
-    def parse(cls, version):
+    def parse(cls, version: str) -> "SemVerWithVPrefix":
         """
         Parse version string to a Version instance.
 
         :param version: version string with "v" or "V" prefix
-        :type version: str
         :raises ValueError: when version does not start with "v" or "V"
         :return: a new instance
-        :rtype: :class:`SemVerWithVPrefix`
         """
         if not version[0] in ("v", "V"):
             raise ValueError(
@@ -23,9 +21,8 @@ class SemVerWithVPrefix(Version):
                     v=version
                 )
             )
-        self = super(SemVerWithVPrefix, cls).parse(version[1:])
-        return self
+        return super().parse(version[1:])
 
-    def __str__(self):
+    def __str__(self) -> str:
         # Reconstruct the tag
-        return "v" + super(SemVerWithVPrefix, self).__str__()
+        return "v" + super().__str__()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,7 @@
 Using semver
 ============
 
-The ``semver`` module can store a version in the :class:`semver.Version` class.
+The :mod:`semver` module can store a version in the :class:`~semver.version.Version` class.
 For historical reasons, a version can be also stored as a string or dictionary.
 
 Each type can be converted into the other, if the minimum requirements
@@ -32,69 +32,53 @@ To know the version of semver itself, use the following construct::
 Creating a Version
 ------------------
 
-Due to historical reasons, the semver project offers two ways of
-creating a version:
+.. versionchanged:: 3.0.0
 
-* through an object oriented approach with the :class:`semver.Version`
-  class. This is the preferred method when using semver.
+  The former :class:`~semver.version.VersionInfo`
+  has been renamed to :class:`~semver.version.Version`.
 
-* through module level functions and builtin datatypes (usually string
-  and dict).
-  This method is still available for compatibility reasons, but are
-  marked as deprecated. Using it will emit a :class:`DeprecationWarning`.
+The preferred way to create a new version is with the class
+:class:`~semver.version.Version`.
 
+.. note::
 
-.. warning:: **Deprecation Warning**
+   In the previous major release semver 2 it was possible to
+   create a version with module level functions.
+   However, module level functions are marked as *deprecated*
+   since version 2.x.y now.
+   These functions will be removed in semver 3.1.0.
+   For details, see the sections :ref:`sec_replace_deprecated_functions`
+   and :ref:`sec_display_deprecation_warnings`.
 
-    Module level functions are marked as *deprecated* in version 2.x.y now.
-    These functions will be removed in semver 3.
-    For details, see the sections :ref:`sec_replace_deprecated_functions` and
-    :ref:`sec_display_deprecation_warnings`.
+A :class:`~semver.version.Version` instance can be created in different ways:
 
+* From a Unicode string::
 
-A :class:`semver.Version` instance can be created in different ways:
-
-* From a string (a Unicode string in Python 2)::
-
-    >>> semver.Version.parse("3.4.5-pre.2+build.4")
+    >>> from semver.version import Version
+    >>> Version.parse("3.4.5-pre.2+build.4")
     Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
-    >>> semver.Version.parse(u"5.3.1")
+    >>> Version.parse(u"5.3.1")
     Version(major=5, minor=3, patch=1, prerelease=None, build=None)
 
 * From a byte string::
 
-    >>> semver.Version.parse(b"2.3.4")
+    >>> Version.parse(b"2.3.4")
     Version(major=2, minor=3, patch=4, prerelease=None, build=None)
 
 * From individual parts by a dictionary::
 
     >>> d = {'major': 3, 'minor': 4, 'patch': 5,  'prerelease': 'pre.2', 'build': 'build.4'}
-    >>> semver.Version(**d)
+    >>> Version(**d)
     Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
 
   Keep in mind, the ``major``, ``minor``, ``patch`` parts has to
-    be positive.
+  be positive integers or strings:
 
-      >>> semver.Version(-1)
+      >>> d = {'major': -3, 'minor': 4, 'patch': 5,  'prerelease': 'pre.2', 'build': 'build.4'}
+      >>> Version(**d)
       Traceback (most recent call last):
       ...
       ValueError: 'major' is negative. A version can only be positive.
-
-    As a minimum requirement, your dictionary needs at least the
-    be positive.
-
-      >>> semver.Version(-1)
-      Traceback (most recent call last):
-      ...
-      ValueError: 'major' is negative. A version can only be positive.
-
-    As a minimum requirement, your dictionary needs at least the
-    be positive.
-
-    >>> semver.Version(-1)
-    Traceback (most recent call last):
-    ...
-    ValueError: 'major' is negative. A version can only be positive.
 
   As a minimum requirement, your dictionary needs at least the ``major``
   key, others can be omitted. You get a ``TypeError`` if your
@@ -105,20 +89,23 @@ A :class:`semver.Version` instance can be created in different ways:
 * From a tuple::
 
     >>> t = (3, 5, 6)
-    >>> semver.Version(*t)
+    >>> Version(*t)
     Version(major=3, minor=5, patch=6, prerelease=None, build=None)
 
   You can pass either an integer or a string for ``major``, ``minor``, or
   ``patch``::
 
-    >>> semver.Version("3", "5", 6)
+    >>> Version("3", "5", 6)
     Version(major=3, minor=5, patch=6, prerelease=None, build=None)
 
-The old, deprecated module level functions are still available. If you
-need them, they return different builtin objects (string and dictionary).
+The old, deprecated module level functions are still available but
+using them are discoraged. They are available to convert old code
+to semver3.
+
+If you need them, they return different builtin objects (string and dictionary).
 Keep in mind, once you have converted a version into a string or dictionary,
 it's an ordinary builtin object. It's not a special version object like
-the :class:`semver.Version` class anymore.
+the :class:`~semver.version.Version` class anymore.
 
 Depending on your use case, the following methods are available:
 
@@ -136,7 +123,7 @@ Depending on your use case, the following methods are available:
     >>> semver.parse("3.4.5-pre.2+build.4")
     OrderedDict([('major', 3), ('minor', 4), ('patch', 5), ('prerelease', 'pre.2'), ('build', 'build.4')])
 
-  If you pass an invalid version string you will get a ``ValueError``::
+  If you pass an invalid version string you will get a :py:exc:`ValueError`::
 
     >>> semver.parse("1.2")
     Traceback (most recent call last):
@@ -148,36 +135,23 @@ Parsing a Version String
 ------------------------
 
 "Parsing" in this context means to identify the different parts in a string.
+Use the function :func:`Version.parse <semver.version.Version.parse>`::
 
-
-* With :func:`semver.parse_version_info`::
-
-    >>> semver.parse_version_info("3.4.5-pre.2+build.4")
+    >>> Version.parse("3.4.5-pre.2+build.4")
     Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
-
-* With :func:`semver.Version.parse` (basically the same as
-  :func:`semver.parse_version_info`)::
-
-    >>> semver.Version.parse("3.4.5-pre.2+build.4")
-    Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
-
-* With :func:`semver.parse`::
-
-    >>> semver.parse("3.4.5-pre.2+build.4") == {'major': 3, 'minor': 4, 'patch': 5, 'prerelease': 'pre.2', 'build': 'build.4'}
-    True
 
 
 Checking for a Valid Semver Version
 -----------------------------------
 
 If you need to check a string if it is a valid semver version, use the
-classmethod :func:`semver.Version.isvalid`:
+classmethod :func:`Version.isvalid <semver.version.Version.isvalid>`:
 
 .. code-block:: python
 
-    >>> semver.Version.isvalid("1.0.0")
+    >>> Version.isvalid("1.0.0")
     True
-    >>> semver.Version.isvalid("invalid")
+    >>> Version.isvalid("invalid")
     False
 
 
@@ -186,12 +160,12 @@ classmethod :func:`semver.Version.isvalid`:
 Accessing Parts of a Version Through Names
 ------------------------------------------
 
-The :class:`semver.Version` contains attributes to access the different
+The :class:`~semver.version.Version` class contains attributes to access the different
 parts of a version:
 
 .. code-block:: python
 
-    >>> v = semver.Version.parse("3.4.5-pre.2+build.4")
+    >>> v = Version.parse("3.4.5-pre.2+build.4")
     >>> v.major
     3
     >>> v.minor
@@ -203,8 +177,8 @@ parts of a version:
     >>> v.build
     'build.4'
 
-However, the attributes are read-only. You cannot change an attribute.
-If you do, you get an ``AttributeError``::
+However, the attributes are read-only. You cannot change any of the above attributes.
+If you do, you get an :py:exc:`AttributeError`::
 
     >>> v.minor = 5
     Traceback (most recent call last):
@@ -213,16 +187,16 @@ If you do, you get an ``AttributeError``::
 
 If you need to replace different parts of a version, refer to section :ref:`sec.replace.parts`.
 
-In case you need the different parts of a version stepwise, iterate over the :class:`semver.Version` instance::
+In case you need the different parts of a version stepwise, iterate over the :class:`~semver.version.Version` instance::
 
-    >>> for item in semver.Version.parse("3.4.5-pre.2+build.4"):
+    >>> for item in Version.parse("3.4.5-pre.2+build.4"):
     ...     print(item)
     3
     4
     5
     pre.2
     build.4
-    >>> list(semver.Version.parse("3.4.5-pre.2+build.4"))
+    >>> list(Version.parse("3.4.5-pre.2+build.4"))
     [3, 4, 5, 'pre.2', 'build.4']
 
 
@@ -234,15 +208,15 @@ Accessing Parts Through Index Numbers
 .. versionadded:: 2.10.0
 
 Another way to access parts of a version is to use an index notation. The underlying
-:class:`Version <semver.Version>` object allows to access its data through
-the magic method :func:`__getitem__ <semver.Version.__getitem__>`.
+:class:`~semver.version.Version` object allows to access its data through
+the magic method :func:`~semver.version.Version.__getitem__`.
 
 For example, the ``major`` part can be accessed by index number 0 (zero).
 Likewise the other parts:
 
 .. code-block:: python
 
-    >>> ver = semver.Version.parse("10.3.2-pre.5+build.10")
+    >>> ver = Version.parse("10.3.2-pre.5+build.10")
     >>> ver[0], ver[1], ver[2], ver[3], ver[4]
     (10, 3, 2, 'pre.5', 'build.10')
 
@@ -261,11 +235,11 @@ Or, as an alternative, you can pass a :func:`slice` object:
     >>> ver[sl]
     (10, 3, 2)
 
-Negative numbers or undefined parts raise an :class:`IndexError` exception:
+Negative numbers or undefined parts raise an :py:exc:`IndexError` exception:
 
 .. code-block:: python
 
-    >>> ver = semver.Version.parse("10.3.2")
+    >>> ver = Version.parse("10.3.2")
     >>> ver[3]
     Traceback (most recent call last):
     ...
@@ -281,9 +255,9 @@ Replacing Parts of a Version
 ----------------------------
 
 If you want to replace different parts of a version, but leave other parts
-unmodified, use the function :func:`semver.Version.replace` or :func:`semver.replace`:
+unmodified, use the function :func:`replace <semver.version.Version.replace>`:
 
-* From a :class:`semver.Version` instance::
+* From a :class:`Version <semver.version.Version>` instance::
 
    >>> version = semver.Version.parse("1.4.5-pre.1+build.6")
    >>> version.replace(major=2, minor=2)
@@ -312,25 +286,25 @@ If you pass invalid keys you get an exception::
 Converting a Version instance into Different Types
 ------------------------------------------------------
 
-Sometimes it is needed to convert a :class:`semver.Version` instance into
+Sometimes it is needed to convert a :class:`Version <semver.version.Version>` instance into
 a different type. For example, for displaying or to access all parts.
 
-It is possible to convert a :class:`semver.Version` instance:
+It is possible to convert a :class:`Version <semver.version.Version>` instance:
 
 * Into a string with the builtin function :func:`str`::
 
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4"))
+    >>> str(Version.parse("3.4.5-pre.2+build.4"))
     '3.4.5-pre.2+build.4'
 
-* Into a dictionary with :func:`semver.Version.to_dict`::
+* Into a dictionary with :func:`to_dict <semver.version.Version.to_dict>`::
 
-    >>> v = semver.Version(major=3, minor=4, patch=5)
+    >>> v = Version(major=3, minor=4, patch=5)
     >>> v.to_dict()
     OrderedDict([('major', 3), ('minor', 4), ('patch', 5), ('prerelease', None), ('build', None)])
 
-* Into a tuple with :func:`semver.Version.to_tuple`::
+* Into a tuple with :func:`to_tuple <semver.version.Version.to_tuple>`::
 
-    >>> v = semver.Version(major=5, minor=4, patch=2)
+    >>> v = Version(major=5, minor=4, patch=2)
     >>> v.to_tuple()
     (5, 4, 2, None, None)
 
@@ -341,27 +315,27 @@ Raising Parts of a Version
 The ``semver`` module contains the following functions to raise parts of
 a version:
 
-* :func:`semver.Version.bump_major`: raises the major part and set all other parts to
+* :func:`Version.bump_major <semver.version.Version.bump_major>`: raises the major part and set all other parts to
   zero. Set ``prerelease`` and ``build`` to ``None``.
-* :func:`semver.Version.bump_minor`: raises the minor part and sets ``patch`` to zero.
+* :func:`Version.bump_minor <semver.version.Version.bump_minor>`: raises the minor part and sets ``patch`` to zero.
   Set ``prerelease`` and ``build`` to ``None``.
-* :func:`semver.Version.bump_patch`: raises the patch part. Set ``prerelease`` and
+* :func:`Version.bump_patch <semver.version.Version.bump_patch>`: raises the patch part. Set ``prerelease`` and
   ``build`` to ``None``.
-* :func:`semver.Version.bump_prerelease`: raises the prerelease part and set
+* :func:`Version.bump_prerelease <semver.version.Version.bump_prerelease>`: raises the prerelease part and set
   ``build`` to ``None``.
-* :func:`semver.Version.bump_build`: raises the build part.
+* :func:`Version.bump_build <semver.version.Version.bump_build>`: raises the build part.
 
 .. code-block:: python
 
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4").bump_major())
+    >>> str(Version.parse("3.4.5-pre.2+build.4").bump_major())
     '4.0.0'
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4").bump_minor())
+    >>> str(Version.parse("3.4.5-pre.2+build.4").bump_minor())
     '3.5.0'
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4").bump_patch())
+    >>> str(Version.parse("3.4.5-pre.2+build.4").bump_patch())
     '3.4.6'
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4").bump_prerelease())
+    >>> str(Version.parse("3.4.5-pre.2+build.4").bump_prerelease())
     '3.4.5-pre.3'
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4").bump_build())
+    >>> str(Version.parse("3.4.5-pre.2+build.4").bump_build())
     '3.4.5-pre.2+build.5'
 
 Likewise the module level functions :func:`semver.bump_major`.
@@ -371,23 +345,23 @@ Increasing Parts of a Version Taking into Account Prereleases
 -------------------------------------------------------------
 
 .. versionadded:: 2.10.0
-   Added :func:`semver.Version.next_version`.
+   Added :func:`Version.next_version <semver.version.Version.next_version>`.
 
 If you want to raise your version and take prereleases into account,
-the function :func:`semver.Version.next_version` would perhaps a
-better fit.
+the function :func:`next_version <semver.version.Version.next_version>`
+would perhaps a better fit.
 
 
 .. code-block:: python
 
-    >>> v = semver.Version.parse("3.4.5-pre.2+build.4")
+    >>> v = Version.parse("3.4.5-pre.2+build.4")
     >>> str(v.next_version(part="prerelease"))
     '3.4.5-pre.3'
-    >>> str(semver.Version.parse("3.4.5-pre.2+build.4").next_version(part="patch"))
+    >>> str(Version.parse("3.4.5-pre.2+build.4").next_version(part="patch"))
     '3.4.5'
-    >>> str(semver.Version.parse("3.4.5+build.4").next_version(part="patch"))
+    >>> str(Version.parse("3.4.5+build.4").next_version(part="patch"))
     '3.4.5'
-    >>> str(semver.Version.parse("0.1.4").next_version("prerelease"))
+    >>> str(Version.parse("0.1.4").next_version("prerelease"))
     '0.1.5-rc.1'
 
 
@@ -410,23 +384,23 @@ To compare two versions depends on your type:
   The return value is negative if ``version1 < version2``, zero if
   ``version1 == version2`` and strictly positive if ``version1 > version2``.
 
-* **Two** :class:`semver.Version` **instances**
+* **Two** :class:`Version <semver.version.Version>` **instances**
 
   Use the specific operator. Currently, the operators ``<``,
   ``<=``, ``>``, ``>=``, ``==``, and ``!=`` are supported::
 
-    >>> v1 = semver.Version.parse("3.4.5")
-    >>> v2 = semver.Version.parse("3.5.1")
+    >>> v1 = Version.parse("3.4.5")
+    >>> v2 = Version.parse("3.5.1")
     >>> v1 < v2
     True
     >>> v1 > v2
     False
 
-* **A** :class:`semver.Version` **type and a** :func:`tuple` **or** :func:`list`
+* **A** :class:`Version <semver.version.Version>` **type and a** :func:`tuple` **or** :func:`list`
 
-  Use the operator as with two :class:`semver.Version` types::
+  Use the operator as with two :class:`Version <semver.version.Version>` types::
 
-    >>> v = semver.Version.parse("3.4.5")
+    >>> v = Version.parse("3.4.5")
     >>> v > (1, 0)
     True
     >>> v < [3, 5]
@@ -439,7 +413,7 @@ To compare two versions depends on your type:
     >>> [3, 5] > v
     True
 
-* **A** :class:`semver.Version` **type and a** :func:`str`
+* **A** :class:`Version <semver.version.Version>` **type and a** :func:`str`
 
   You can use also raw strings to compare::
 
@@ -455,14 +429,14 @@ To compare two versions depends on your type:
     >>> "3.5.0" > v
     True
 
-  However, if you compare incomplete strings, you get a :class:`ValueError` exception::
+  However, if you compare incomplete strings, you get a :py:exc:`ValueError` exception::
 
     >>> v > "1.0"
     Traceback (most recent call last):
     ...
     ValueError: 1.0 is not valid SemVer string
 
-* **A** :class:`semver.Version` **type and a** :func:`dict`
+* **A** :class:`Version <semver.version.Version>` **type and a** :func:`dict`
 
   You can also use a dictionary. In contrast to strings, you can have an "incomplete"
   version (as the other parts are set to zero)::
@@ -475,7 +449,7 @@ To compare two versions depends on your type:
    >>> dict(major=1) < v
    True
 
-  If the dictionary contains unknown keys, you get a :class:`TypeError` exception::
+  If the dictionary contains unknown keys, you get a :py:exc:`TypeError` exception::
 
     >>> v > dict(major=1, unknown=42)
     Traceback (most recent call last):
@@ -499,16 +473,16 @@ Version equality means for semver, that major, minor, patch, and prerelease
 parts are equal in both versions you compare. The build part is ignored.
 For example::
 
-    >>> v = semver.Version.parse("1.2.3-rc4+1e4664d")
+    >>> v = Version.parse("1.2.3-rc4+1e4664d")
     >>> v == "1.2.3-rc4+dedbeef"
     True
 
-This also applies when a :class:`semver.Version` is a member of a set, or a
+This also applies when a :class:`Version <semver.version.Version>` is a member of a set, or a
 dictionary key::
 
     >>> d = {}
-    >>> v1 = semver.Version.parse("1.2.3-rc4+1e4664d")
-    >>> v2 = semver.Version.parse("1.2.3-rc4+dedbeef")
+    >>> v1 = Version.parse("1.2.3-rc4+1e4664d")
+    >>> v2 = Version.parse("1.2.3-rc4+dedbeef")
     >>> d[v1] = 1
     >>> d[v2]
     1
@@ -554,34 +528,36 @@ Getting Minimum and Maximum of Multiple Versions
    The functions :func:`semver.max_ver` and :func:`semver.min_ver` are deprecated in
    favor of their builtin counterparts :func:`max` and :func:`min`.
 
-Since :class:`semver.Version` implements :func:`__gt__()` and :func:`__lt__()`, it can be used with builtins requiring
+Since :class:`Version <semver.version.Version>` implements
+:func:`__gt__ <semver.version.Version.__gt__>` and
+:func:`__lt__ <semver.version.Version.__lt__>`, it can be used with builtins requiring:
 
 .. code-block:: python
 
-    >>> max([semver.Version(0, 1, 0), semver.Version(0, 2, 0), semver.Version(0, 1, 3)])
+    >>> max([Version(0, 1, 0), Version(0, 2, 0), Version(0, 1, 3)])
     Version(major=0, minor=2, patch=0, prerelease=None, build=None)
-    >>> min([semver.Version(0, 1, 0), semver.Version(0, 2, 0), semver.Version(0, 1, 3)])
+    >>> min([Version(0, 1, 0), Version(0, 2, 0), Version(0, 1, 3)])
     Version(major=0, minor=1, patch=0, prerelease=None, build=None)
 
 Incidentally, using :func:`map`, you can get the min or max version of any number of versions of the same type
-(convertible to :class:`semver.Version`).
+(convertible to :class:`Version <semver.version.Version>`).
 
 For example, here are the maximum and minimum versions of a list of version strings:
 
 .. code-block:: python
 
-    >>> str(max(map(semver.Version.parse, ['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'])))
+    >>> str(max(map(Version.parse, ['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'])))
     '2.1.0'
-    >>> str(min(map(semver.Version.parse, ['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'])))
+    >>> str(min(map(Version.parse, ['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'])))
     '0.4.99'
 
 And the same can be done with tuples:
 
 .. code-block:: python
 
-    >>> max(map(lambda v: semver.Version(*v), [(1, 1, 0), (1, 2, 0), (2, 1, 0), (0, 5, 10), (0, 4, 99)])).to_tuple()
+    >>> max(map(lambda v: Version(*v), [(1, 1, 0), (1, 2, 0), (2, 1, 0), (0, 5, 10), (0, 4, 99)])).to_tuple()
     (2, 1, 0, None, None)
-    >>> min(map(lambda v: semver.Version(*v), [(1, 1, 0), (1, 2, 0), (2, 1, 0), (0, 5, 10), (0, 4, 99)])).to_tuple()
+    >>> min(map(lambda v: Version(*v), [(1, 1, 0), (1, 2, 0), (2, 1, 0), (0, 5, 10), (0, 4, 99)])).to_tuple()
     (0, 4, 99, None, None)
 
 For dictionaries, it is very similar to finding the max version tuple: see :ref:`sec.convert.versions`.
@@ -616,7 +592,7 @@ information and returns a tuple with two items:
    :language: python
 
 
-The function returns a *tuple*, containing a :class:`Version`
+The function returns a *tuple*, containing a :class:`Version <semver.version.Version>`
 instance or None as the first element and the rest as the second element.
 The second element (the rest) can be used to make further adjustments.
 
@@ -649,7 +625,7 @@ them with code which is compatible for future versions:
 
 * :func:`semver.bump_major`, :func:`semver.bump_minor`, :func:`semver.bump_patch`, :func:`semver.bump_prerelease`, :func:`semver.bump_build`
 
-  Replace them with the respective methods of the :class:`semver.Version`
+  Replace them with the respective methods of the :class:`Version <semver.version.Version>`
   class.
   For example, the function :func:`semver.bump_major` is replaced by
   :func:`semver.Version.bump_major` and calling the ``str(versionobject)``:
@@ -657,7 +633,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> s1 = semver.bump_major("3.4.5")
-     >>> s2 = str(semver.Version.parse("3.4.5").bump_major())
+     >>> s2 = str(Version.parse("3.4.5").bump_major())
      >>> s1 == s2
      True
 
@@ -681,7 +657,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> s1 = semver.format_version(5, 4, 3, 'pre.2', 'build.1')
-     >>> s2 = str(semver.Version(5, 4, 3, 'pre.2', 'build.1'))
+     >>> s2 = str(Version(5, 4, 3, 'pre.2', 'build.1'))
      >>> s1 == s2
      True
 
@@ -692,7 +668,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> s1 = semver.max_ver("1.2.3", "1.2.4")
-     >>> s2 = str(max(map(semver.Version.parse, ("1.2.3", "1.2.4"))))
+     >>> s2 = str(max(map(Version.parse, ("1.2.3", "1.2.4"))))
      >>> s1 == s2
      True
 
@@ -703,7 +679,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> s1 = semver.min_ver("1.2.3", "1.2.4")
-     >>> s2 = str(min(map(semver.Version.parse, ("1.2.3", "1.2.4"))))
+     >>> s2 = str(min(map(Version.parse, ("1.2.3", "1.2.4"))))
      >>> s1 == s2
      True
 
@@ -715,7 +691,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> v1 = semver.parse("1.2.3")
-     >>> v2 = semver.Version.parse("1.2.3").to_dict()
+     >>> v2 = Version.parse("1.2.3").to_dict()
      >>> v1 == v2
      True
 
@@ -726,7 +702,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> v1 = semver.parse_version_info("3.4.5")
-     >>> v2 = semver.Version.parse("3.4.5")
+     >>> v2 = Version.parse("3.4.5")
      >>> v1 == v2
      True
 
@@ -737,7 +713,7 @@ them with code which is compatible for future versions:
   .. code-block:: python
 
      >>> s1 = semver.replace("1.2.3", major=2, patch=10)
-     >>> s2 = str(semver.Version.parse('1.2.3').replace(major=2, patch=10))
+     >>> s2 = str(Version.parse('1.2.3').replace(major=2, patch=10))
      >>> s1 == s2
      True
 
@@ -785,7 +761,7 @@ Creating Subclasses from Version
 
 If you do not like creating functions to modify the behavior of semver
 (as shown in section :ref:`sec_dealing_with_invalid_versions`), you can
-also create a subclass of the :class:`Version` class.
+also create a subclass of the :class:`Version <semver.version.Version>` class.
 
 For example, if you want to output a "v" prefix before a version,
 but the other behavior is the same, use the following code:
@@ -811,4 +787,3 @@ the original class:
      Traceback (most recent call last):
      ...
      ValueError: '1.2.4': not a valid semantic version tag. Must start with 'v' or 'V'
-


### PR DESCRIPTION
This PR fixes #312 and contains the following changes:

* Correct `:class:` directive and use `:class:~semver.version.Version`
* Mention the rename of VersionInfo -> Version class
* Remove semver. prefix in doctests to make examples shorter
* Correct some references to dunder methods like `__getitem__`, `__gt__` etc.
* Use `:py:exec:` reference to Python exceptions.
* Remove inconsistencies and mention module level function as deprecated and discouraged from using
* Use empty `super()` call in `semverwithvprefix.py` example instead of the more verbose `super(SemVerWithVPrefix, self)`