### PR TITLE
Fix #316: Return NotImplemented for comparisons

### DIFF
--- a/changelog.d/316.trivial.rst
+++ b/changelog.d/316.trivial.rst
@@ -1,0 +1,10 @@
+Comparisons of :class:`~semver.version.Version` class and other
+types return now a :py:const:`NotImplemented` constant instead
+of a :py:exc:`TypeError` exception.
+
+The `NotImplemented`_ section of the Python documentation recommends
+returning this constant when comparing with ``__gt__``, ``__lt__``,
+and other comparison operators to "to indicate that the operation is
+not implemented with respect to the other type".
+
+.. _NotImplemented: https://docs.python.org/3/library/constants.html#NotImplemented

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -72,9 +72,7 @@ def comparator(operator: Comparator) -> Comparator:
             *String.__args__,  # type: ignore
         )
         if not isinstance(other, comparable_types):
-            raise TypeError(
-                "other type %r must be in %r" % (type(other), comparable_types)
-            )
+            return NotImplemented
         return operator(self, other)
 
     return wrapper


### PR DESCRIPTION
The former code raised a `TypeError` exception for comparisons like `__gt__`, `__lt__` etc. to indicate a wrong type.

However, according to [NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented) documentation, we should return(!) NotImplemented (not raise) when a comparison with an invalid type is not implemented.