### PR TITLE
Fix #309: Make some functions private

### DIFF
--- a/changelog.d/309.trivial.rst
+++ b/changelog.d/309.trivial.rst
@@ -1,0 +1,17 @@
+Some (private) functions from the :mod:`semver.version`
+module has been changed.
+
+The following functions got renamed:
+
+* function ``semver.version.comparator`` got renamed to
+  :func:`semver.version._comparator` as it is only useful
+  inside the :class:`~semver.version.Version` class.
+* function ``semver.version.cmp`` got renamed to
+  :func:`semver.version._cmp` as it is only useful
+  inside the :class:`~semver.version.Version` class.
+
+The following functions got integrated into the
+:class:`~semver.version.Version` class:
+
+* function ``semver.version._nat_cmd`` as a classmethod
+* function ``semver.version.ensure_str``

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,12 +50,6 @@ Version Handling :mod:`semver.version`
 
 .. automodule:: semver.version
 
-.. autofunction:: semver.version.cmp
-
-.. autofunction:: semver.version.ensure_str
-
-.. autofunction:: semver.version.comparator
-
 .. autoclass:: semver.version.VersionInfo
 
 .. autoclass:: semver.version.Version

--- a/tests/test_typeerror-274.py
+++ b/tests/test_typeerror-274.py
@@ -1,95 +1,14 @@
-import sys
-
 import pytest
-
 import semver
-import semver.version
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
 
-def ensure_binary(s, encoding="utf-8", errors="strict"):
-    """
-    Coerce ``s`` to bytes.
-
-    * `str` -> encoded to `bytes`
-    * `bytes` -> `bytes`
-
-    :param s: the string to convert
-    :type s: str | bytes
-    :param encoding: the encoding to apply, defaults to "utf-8"
-    :type encoding: str
-    :param errors: set a different error handling scheme;
-      other possible values are `ignore`, `replace`, and
-      `xmlcharrefreplace` as well as any other name
-      registered with :func:`codecs.register_error`.
-      Defaults to "strict".
-    :type errors: str
-    :raises TypeError: if ``s`` is not str or bytes type
-    :return: the converted string
-    :rtype: str
-    """
-    if isinstance(s, str):
-        return s.encode(encoding, errors)
-    elif isinstance(s, bytes):
-        return s
-    else:
-        raise TypeError("not expecting type '%s'" % type(s))
-
-
-def test_should_work_with_string_and_unicode():
+def test_should_work_with_string_and_bytes():
     result = semver.compare("1.1.0", b"1.2.2")
     assert result == -1
     result = semver.compare(b"1.1.0", "1.2.2")
     assert result == -1
 
 
-class TestEnsure:
-    # From six project
-    # grinning face emoji
-    UNICODE_EMOJI = "\U0001F600"
-    BINARY_EMOJI = b"\xf0\x9f\x98\x80"
-
-    def test_ensure_binary_raise_type_error(self):
-        with pytest.raises(TypeError):
-            semver.version.ensure_str(8)
-
-    def test_errors_and_encoding(self):
-        ensure_binary(self.UNICODE_EMOJI, encoding="latin-1", errors="ignore")
-        with pytest.raises(UnicodeEncodeError):
-            ensure_binary(self.UNICODE_EMOJI, encoding="latin-1", errors="strict")
-
-    def test_ensure_binary_raise(self):
-        converted_unicode = ensure_binary(
-            self.UNICODE_EMOJI, encoding="utf-8", errors="strict"
-        )
-        converted_binary = ensure_binary(
-            self.BINARY_EMOJI, encoding="utf-8", errors="strict"
-        )
-
-        # PY3: str -> bytes
-        assert converted_unicode == self.BINARY_EMOJI and isinstance(
-            converted_unicode, bytes
-        )
-        # PY3: bytes -> bytes
-        assert converted_binary == self.BINARY_EMOJI and isinstance(
-            converted_binary, bytes
-        )
-
-    def test_ensure_str(self):
-        converted_unicode = semver.version.ensure_str(
-            self.UNICODE_EMOJI, encoding="utf-8", errors="strict"
-        )
-        converted_binary = semver.version.ensure_str(
-            self.BINARY_EMOJI, encoding="utf-8", errors="strict"
-        )
-
-        # PY3: str -> str
-        assert converted_unicode == self.UNICODE_EMOJI and isinstance(
-            converted_unicode, str
-        )
-        # PY3: bytes -> str
-        assert converted_binary == self.UNICODE_EMOJI and isinstance(
-            converted_unicode, str
-        )
+def test_should_not_work_with_invalid_args():
+    with pytest.raises(TypeError):
+        semver.version.Version.parse(8)


### PR DESCRIPTION
This PR fixes #309 and contains:

* Rename `comparator` -> `_comparator`, `cmp` -> `_cmp`
* Remove `ensure_str` and integrate it into `Version.parse`
* Rework tests in `test_typeerror-274.py`
* Move `_nat_cmp` to `Version` and make it a class method
* Remove private functions from API documentation