### PR TITLE
Fix tests for Python 3.10

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -455,7 +455,7 @@ To compare two versions depends on your type:
     >>> v > dict(major=1, unknown=42)
     Traceback (most recent call last):
     ...
-    TypeError: __init__() got an unexpected keyword argument 'unknown'
+    TypeError: ...__init__() got an unexpected keyword argument 'unknown'
 
 
 Other types cannot be compared.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -455,7 +455,7 @@ To compare two versions depends on your type:
     >>> v > dict(major=1, unknown=42)
     Traceback (most recent call last):
     ...
-    TypeError: ...__init__() got an unexpected keyword argument 'unknown'
+    TypeError: ... got an unexpected keyword argument 'unknown'
 
 
 Other types cannot be compared.
@@ -786,4 +786,3 @@ the original class:
      Traceback (most recent call last):
      ...
      ValueError: '1.2.4': not a valid semantic version tag. Must start with 'v' or 'V'
-


### PR DESCRIPTION
This simple fix makes tests pass with Python 3.10. Without it, the error is:
```
453   If the dictionary contains unknown keys, you get a :class:`TypeError` exception::
454 
455     >>> v > dict(major=1, unknown=42)
Differences (ndiff with -expected +actual):
      Traceback (most recent call last):
    - ...
    +   File "/usr/lib64/python3.10/doctest.py", line 1340, in __run
    +     exec(compile(example.source, filename, "single",
    +   File "<doctest usage.rst[75]>", line 1, in <module>
    +     v > dict(major=1, unknown=42)
    +   File "/builddir/build/BUILD/python-semver-2.13.0/semver.py", line 203, in wrapper
    +     return operator(self, other)
    +   File "/builddir/build/BUILD/python-semver-2.13.0/semver.py", line 589, in __gt__
    +     return self.compare(other) > 0
    +   File "/builddir/build/BUILD/python-semver-2.13.0/semver.py", line 495, in compare
    +     other = cls(**other)
    - TypeError: __init__() got an unexpected keyword argument 'unknown'
    + TypeError: VersionInfo.__init__() got an unexpected keyword argument 'unknown'
    ?            ++++++++++++
```