### PR TITLE
Improve suggestion for finding max and min using semver

### DIFF
--- a/docs/migratetosemver3.rst
+++ b/docs/migratetosemver3.rst
@@ -20,7 +20,7 @@ Use Version instead of VersionInfo
 The :class:`VersionInfo` has been renamed to :class:`Version`
 to have a more succinct name.
 An alias has been created to preserve compatibility but
-using old name has been deprecated.
+using the old name has been deprecated.
 
 If you still need the old version, use this line:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -546,9 +546,9 @@ For example, here are the maximum and minimum versions of a list of version stri
 
 .. code-block:: python
 
-    >>> str(max(map(Version.parse, ['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'])))
+    >>> max(['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'], key=Version.parse)
     '2.1.0'
-    >>> str(min(map(Version.parse, ['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'])))
+    >>> min(['1.1.0', '1.2.0', '2.1.0', '0.5.10', '0.4.99'], key=Version.parse)
     '0.4.99'
 
 And the same can be done with tuples:

--- a/src/semver/_deprecated.py
+++ b/src/semver/_deprecated.py
@@ -7,11 +7,11 @@ import inspect
 import warnings
 from functools import partial, wraps
 from types import FrameType
-from typing import Type, Union, Callable, cast
+from typing import Type, Callable, cast
 
 from . import cli
 from .version import Version
-from ._types import F, String
+from ._types import Decorator, F, String
 
 
 def deprecated(
@@ -19,7 +19,7 @@ def deprecated(
     replace: str = None,
     version: str = None,
     category: Type[Warning] = DeprecationWarning,
-) -> Union[Callable[..., F], partial]:
+) -> Decorator:
     """
     Decorates a function to output a deprecation warning.
 

--- a/src/semver/_types.py
+++ b/src/semver/_types.py
@@ -1,5 +1,6 @@
 """Typing for semver."""
 
+from functools import partial
 from typing import Union, Optional, Tuple, Dict, Iterable, Callable, TypeVar
 
 VersionPart = Union[int, Optional[str]]
@@ -8,3 +9,4 @@ VersionDict = Dict[str, VersionPart]
 VersionIterator = Iterable[VersionPart]
 String = Union[str, bytes]
 F = TypeVar("F", bound=Callable)
+Decorator = Union[Callable[..., F], partial]


### PR DESCRIPTION
I was reading through the documentation and thought that the suggestion for finding max/min of a list/iterable of strings using `semver` unecessarily complicated, with a `map`, and multiple typecasts. I think using just `max` with `key` as done in this PR is much cleaner and should be the de-facto suggestion.

This is my first contribution to this repository, I hope it's welcome and I've followed the contribution guide well - but feel free to let me know if I can improve anything or close this PR if it's unwanted :)