### PR TITLE
Added pydantic integration for Version

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -787,3 +787,18 @@ the original class:
      Traceback (most recent call last):
      ...
      ValueError: '1.2.4': not a valid semantic version tag. Must start with 'v' or 'V'
+
+Integrating with Pydantic
+-------------------------------------
+
+If you are building a Pydantic model, you can use :class:`~semver.version.Version` directly.
+An appropriate :class:`pydantic.ValidationError` will be raised for invalid version numbers.
+
+.. code-block:: python
+
+    >>> from semver.version import Version
+    >>> from pydantic import create_model
+    >>> Model = create_model('Model', version=(Version, ...))
+    >>> model = Model(version="3.4.5-pre.2+build.4")
+    >>> model.version
+    Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -1,28 +1,22 @@
 """Version handling."""
 
-import collections
 import re
-from functools import wraps
+import collections
 from typing import (
     Any,
     Dict,
-    Iterable,
-    Optional,
-    SupportsInt,
     Tuple,
     Union,
-    cast,
     Callable,
+    Iterable,
+    Optional,
     Collection,
+    SupportsInt,
+    cast,
 )
+from functools import wraps
 
-from ._types import (
-    VersionTuple,
-    VersionDict,
-    VersionIterator,
-    String,
-    VersionPart,
-)
+from ._types import String, VersionDict, VersionPart, VersionTuple, VersionIterator
 
 # These types are required here because of circular imports
 Comparable = Union["Version", Dict[str, VersionPart], Collection[VersionPart], str]
@@ -551,6 +545,18 @@ build='build.10')
         cmp_res = self.compare(match_version)
 
         return cmp_res in possibilities
+
+    @classmethod
+    def __get_validators__(cls):
+        """Return a list of validator methods for pydantic models."""
+
+        yield cls.parse
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        """Inject/mutate the pydantic field schema in-place."""
+
+        field_schema.update(examples=["1.0.2", "2.15.3-alpha", "21.3.15-beta+12345"])
 
     @classmethod
     def parse(cls, version: String) -> "Version":

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -1,0 +1,109 @@
+import pytest
+import pydantic
+
+from semver import Version
+
+
+class Schema(pydantic.BaseModel):
+    """An example schema which contains a semver Version object"""
+
+    name: str
+    """ Other data which isn't important """
+    version: Version
+    """ Version number auto-parsed by Pydantic """
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        # no. 1
+        (
+            "1.2.3-alpha.1.2+build.11.e0f985a",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "alpha.1.2",
+                "build": "build.11.e0f985a",
+            },
+        ),
+        # no. 2
+        (
+            "1.2.3-alpha-1+build.11.e0f985a",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "alpha-1",
+                "build": "build.11.e0f985a",
+            },
+        ),
+        (
+            "0.1.0-0f",
+            {"major": 0, "minor": 1, "patch": 0, "prerelease": "0f", "build": None},
+        ),
+        (
+            "0.0.0-0foo.1",
+            {"major": 0, "minor": 0, "patch": 0, "prerelease": "0foo.1", "build": None},
+        ),
+        (
+            "0.0.0-0foo.1+build.1",
+            {
+                "major": 0,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": "0foo.1",
+                "build": "build.1",
+            },
+        ),
+    ],
+)
+def test_should_parse_version(version, expected):
+    result = Schema(name="test", version=version)
+    assert result.version == expected
+
+
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        # no. 1
+        (
+            "1.2.3-rc.0+build.0",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "rc.0",
+                "build": "build.0",
+            },
+        ),
+        # no. 2
+        (
+            "1.2.3-rc.0.0+build.0",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 3,
+                "prerelease": "rc.0.0",
+                "build": "build.0",
+            },
+        ),
+    ],
+)
+def test_should_parse_zero_prerelease(version, expected):
+    result = Schema(name="test", version=version)
+    assert result.version == expected
+
+
+@pytest.mark.parametrize("version", ["01.2.3", "1.02.3", "1.2.03"])
+def test_should_raise_value_error_for_zero_prefixed_versions(version):
+    with pytest.raises(pydantic.ValidationError):
+        Schema(name="test", version=version)
+
+
+def test_should_have_schema_examples():
+    assert Schema.schema()["properties"]["version"]["examples"] == [
+        "1.0.2",
+        "2.15.3-alpha",
+        "21.3.15-beta+12345",
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ commands = pytest {posargs:}
 deps =
     pytest
     pytest-cov
+    pydantic
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
 


### PR DESCRIPTION
This PR adds native [pydantic](https://pydantic-docs.helpmanual.io/) integration to `python-semver`. Pydantic makes defining data schemas/models super easy and intuitive, but doesn't have a native field type for semantic version strings. Custom field types are created by simply including a class method `__get_validators__` on the class which yields methods to validate input syntax and return the resulting type. In this case, the `parse` method functions naturally as the field validator. Pydantic also allows the `__modify_schema__` method to inject extra details about the field into the model schema.

In this case, I simply added the `__modify_schema__` and `__get_validators__` methods to the `Version` class. These two class-methods are one line each. The former injects semantic versioning examples into the generated schema while the latter yields the `Version.parse` method as a validator. The result is that a Pydantic user can do the following:

```py
import pydantic
import semver

class MyModel(pydantic.BaseModel):
  version: semver.Version

# model.version will be an instance of semver.Version
# and the construction will raise a pydantic.ValidationError
# if improperly formatted.
model = MyModel.parse_obj({"version": "1.2.3"})
```

It's worth noting that a `pydantic` user could manually specify `Version.parse` as a validator for the field in their model, but this is less expressive, and the overhead for making `semver.Version` compatible with `pydantic` is relatively low (two one-line class methods).

That being said, I totally understand if you think this is out of scope here, but it seemed like a simple quality of life improvement, and thought I'd throw it out there. I went through the contributing guidelines, and I think I've hit all the marks. Thanks for reviewing/considering! :smiley:

Changes:
- Added two new dunder methods in Version which comply with the custom
field types described [here](https://pydantic-docs.helpmanual.io/usage/types/#classes-with-__get_validators__).
- Updated usage documentation with example for using with `pydantic`.
- Added test case for `pydantic` integration (mainly copied parsing tests, and modified to test `pydantic` integration).
- Added `pydantic` dependency in `tox.ini` for tests cases.
- Verified all tests passed for all python versions with `tox`.