### PR TITLE
Allow shorter version for parsing

### DIFF
--- a/changelog.d/pr359.feature.rst
+++ b/changelog.d/pr359.feature.rst
@@ -1,2 +1,2 @@
-Added optional parameter optional_minor_and_patch to allow optional
+Add optional parameter ``optional_minor_and_patch`` in :meth:`.Version.parse`  to allow optional
 minor and patch parts.

--- a/changelog.d/pr359.feature.rst
+++ b/changelog.d/pr359.feature.rst
@@ -1,0 +1,2 @@
+Added optional parameter optional_minor_and_patch to allow optional
+minor and patch parts.

--- a/docs/usage/parse-version-string.rst
+++ b/docs/usage/parse-version-string.rst
@@ -6,3 +6,10 @@ Use the function :func:`Version.parse <semver.version.Version.parse>`::
 
     >>> Version.parse("3.4.5-pre.2+build.4")
     Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
+
+You can set the parameter ``optional_minor_and_patch=True`` to allow optional
+minor and patch parts. Optional parts are set to zero. But keep in mind, that this
+deviates from the semver specification.::
+
+    >>> Version.parse("1.2", optional_minor_and_patch=True)
+    Version(major=1, minor=2, patch=0, prerelease=None, build=None)

--- a/docs/usage/parse-version-string.rst
+++ b/docs/usage/parse-version-string.rst
@@ -7,9 +7,9 @@ Use the function :func:`Version.parse <semver.version.Version.parse>`::
     >>> Version.parse("3.4.5-pre.2+build.4")
     Version(major=3, minor=4, patch=5, prerelease='pre.2', build='build.4')
 
-You can set the parameter ``optional_minor_and_patch=True`` to allow optional
-minor and patch parts. Optional parts are set to zero. But keep in mind, that this
-deviates from the semver specification.::
+Set the parameter ``optional_minor_and_patch=True`` to allow optional
+minor and patch parts. Optional parts are set to zero. By default (False), the
+version string to parse has to follow the semver specification::
 
     >>> Version.parse("1.2", optional_minor_and_patch=True)
     Version(major=1, minor=2, patch=0, prerelease=None, build=None)

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -79,8 +79,8 @@ class Version:
                 (?:
                     \.
                     (?P<patch>0|[1-9]\d*)
-                ){}
-            ){}
+                ){opt_patch}
+            ){opt_minor}
             (?:-(?P<prerelease>
                 (?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)
                 (?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*
@@ -93,12 +93,12 @@ class Version:
         """
     #: Regex for a semver version
     _REGEX = re.compile(
-        _REGEX_TEMPLATE.format('', ''),
+        _REGEX_TEMPLATE.format(opt_patch='', opt_minor=''),
         re.VERBOSE,
     )
     #: Regex for a semver version that might be shorter
     _REGEX_OPTIONAL_MINOR_AND_PATCH = re.compile(
-        _REGEX_TEMPLATE.format('?', '?'),
+        _REGEX_TEMPLATE.format(opt_patch='?', opt_minor='?'),
         re.VERBOSE,
     )
 

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -574,7 +574,9 @@ build='build.10')
            allow subclasses.
 
         :param version: version string
-        :param optional_minor_and_patch: if set to true, the minor and patch version digits are optional, but this will deviate from the semver spec
+        :param optional_minor_and_patch: if set to true, the version string to parse can contain
+           optional minor and patch parts. Optional parts are set to zero.
+           By default (False), the version string to parse has to follow the semver specification.
         :return: a new :class:`Version` instance
         :raises ValueError: if version is invalid
         :raises TypeError: if version contains the wrong type

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -565,7 +565,11 @@ build='build.10')
         return cmp_res in possibilities
 
     @classmethod
-    def parse(cls, version: String, optional_minor_and_patch: bool = False) -> "Version":
+    def parse(
+        cls,
+        version: String,
+        optional_minor_and_patch: bool = False
+    ) -> "Version":
         """
         Parse version string to a Version instance.
 
@@ -574,9 +578,10 @@ build='build.10')
            allow subclasses.
 
         :param version: version string
-        :param optional_minor_and_patch: if set to true, the version string to parse can contain
-           optional minor and patch parts. Optional parts are set to zero.
-           By default (False), the version string to parse has to follow the semver specification.
+        :param optional_minor_and_patch: if set to true, the version string to parse \
+           can contain optional minor and patch parts. Optional parts are set to zero.
+           By default (False), the version string to parse has to follow the semver
+           specification.
         :return: a new :class:`Version` instance
         :raises ValueError: if version is invalid
         :raises TypeError: if version contains the wrong type

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -576,6 +576,9 @@ build='build.10')
         .. versionchanged:: 2.11.0
            Changed method from static to classmethod to
            allow subclasses.
+        .. versionchanged:: 3.0.0
+           Added optional parameter optional_minor_and_patch to allow optional
+           minor and patch parts.
 
         :param version: version string
         :param optional_minor_and_patch: if set to true, the version string to parse \

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -53,6 +53,56 @@ def test_should_parse_version(version, expected):
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "version,expected",
+    [
+        # no. 1
+        (
+            "1.2-alpha.1.2+build.11.e0f985a",
+            {
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": "alpha.1.2",
+                "build": "build.11.e0f985a",
+            },
+        ),
+        # no. 2
+        (
+            "1-alpha-1+build.11.e0f985a",
+            {
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": "alpha-1",
+                "build": "build.11.e0f985a",
+            },
+        ),
+        (
+            "0.1-0f",
+            {"major": 0, "minor": 1, "patch": 0, "prerelease": "0f", "build": None},
+        ),
+        (
+            "0-0foo.1",
+            {"major": 0, "minor": 0, "patch": 0, "prerelease": "0foo.1", "build": None},
+        ),
+        (
+            "0-0foo.1+build.1",
+            {
+                "major": 0,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": "0foo.1",
+                "build": "build.1",
+            },
+        ),
+    ],
+)
+def test_should_parse_version_with_optional_minor_and_patch(version, expected):
+    result = Version.parse(version, optional_minor_and_patch=True)
+    assert result == expected
+
+
 def test_parse_version_info_str_hash():
     s_version = "1.2.3-alpha.1.2+build.11.e0f985a"
     v = parse_version_info(s_version)


### PR DESCRIPTION
For my personal use I added the possibility to parse a version string that is shorter than `major.minor.patch`, for example `13.5`.

When creating a semver version object using the constructor it is possible to only pass a major version and the other parameters are filled with a default value. So why not give this possibility to the parsing function.

To keep backwards compatibility and the requirement from semver that normal version strings need at least three version numbers, the parsing of shorter version strings must be enabled with a parameter. Without that parameter the old functionality will be executed.

I do not know if this is something you would like to integrate, if not simply close this pull request. Otherwise give me a short feedback, then I will update the documentation and the test suite.