### PR TITLE
Support matching 'equal' when no operator is provided

### DIFF
--- a/changelog.d/pr362.feature.rst
+++ b/changelog.d/pr362.feature.rst
@@ -1,0 +1,2 @@
+Make :meth:`.Version.match` accept a bare version string as match expression, defaulting to
+equality testing.

--- a/docs/usage/compare-versions-through-expression.rst
+++ b/docs/usage/compare-versions-through-expression.rst
@@ -24,3 +24,16 @@ That gives you the following possibilities to express your condition:
     True
     >>> semver.match("1.0.0", ">1.0.0")
     False
+
+If no operator is specified, the match expression is interpreted as a
+version to be compared for equality. This allows handling the common
+case of version compatibility checking through either an exact version
+or a match expression very easy to implement, as the same code will
+handle both cases:
+
+.. code-block:: python
+
+    >>> semver.match("2.0.0", "2.0.0")
+    True
+    >>> semver.match("1.0.0", "3.5.1")
+    False

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -522,7 +522,7 @@ build='build.10')
         """
         Compare self to match a match expression.
 
-        :param match_expr: operator and version; valid operators are
+        :param match_expr: optional operator and version; valid operators are
               ``<```   smaller than
               ``>``   greater than
               ``>=``  greator or equal than
@@ -535,6 +535,8 @@ build='build.10')
         True
         >>> semver.Version.parse("1.0.0").match(">1.0.0")
         False
+        >>> semver.Version.parse("4.0.4").match("4.0.4")
+        True
         """
         prefix = match_expr[:2]
         if prefix in (">=", "<=", "==", "!="):
@@ -542,6 +544,9 @@ build='build.10')
         elif prefix and prefix[0] in (">", "<"):
             prefix = prefix[0]
             match_version = match_expr[1:]
+        elif match_expr and match_expr[0] in "0123456789":
+            prefix = "=="
+            match_version = match_expr
         else:
             raise ValueError(
                 "match_expr parameter should be in format <op><ver>, "

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -26,6 +26,18 @@ def test_should_match_not_equal(left, right, expected):
 @pytest.mark.parametrize(
     "left,right,expected",
     [
+        ("2.3.7", "2.3.7", True),
+        ("2.3.6", "2.3.6", True),
+        ("2.3.7", "4.3.7", False),
+    ],
+)
+def test_should_match_equal_by_default(left, right, expected):
+    assert match(left, right) is expected
+
+
+@pytest.mark.parametrize(
+    "left,right,expected",
+    [
         ("2.3.7", "<2.4.0", True),
         ("2.3.7", ">2.3.5", True),
         ("2.3.7", "<=2.3.9", True),
@@ -49,7 +61,7 @@ def test_should_raise_value_error_for_unexpected_match_expression(left, right):
 
 
 @pytest.mark.parametrize(
-    "left,right", [("1.0.0", ""), ("1.0.0", "!"), ("1.0.0", "1.0.0")]
+    "left,right", [("1.0.0", ""), ("1.0.0", "!")]
 )
 def test_should_raise_value_error_for_invalid_match_expression(left, right):
     with pytest.raises(ValueError):


### PR DESCRIPTION
This makes it easier to work with user-supplied versions, as they may omit the comparison operator and just specify which version they want to select. Equality comparison is a sane default behavior.