### PR TITLE
Fix #284: implement "is compatible with" method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,6 @@ fabric.properties
 
 docs/_api
 !docs/_api/semver.__about__.rst
+
+# For node
+node_modules/

--- a/changelog.d/284.deprecation.rst
+++ b/changelog.d/284.deprecation.rst
@@ -1,0 +1,5 @@
+Deprecate the use of :meth:`Version.isvalid`.
+
+Rename :meth:`Version.isvalid <semver.version.Version.isvalid>`
+to :meth:`Version.is_valid <semver.version.Version.is_valid>`
+for consistency reasons with :meth:`Version.is_compatible <semver.version.Version.is_compatible>`

--- a/changelog.d/284.doc.rst
+++ b/changelog.d/284.doc.rst
@@ -1,0 +1,1 @@
+Document deprecation of :meth:`Version.isvalid`.

--- a/changelog.d/284.feature.rst
+++ b/changelog.d/284.feature.rst
@@ -1,0 +1,1 @@
+Implement :meth:`Version.is_compatible <semver.version.Version.is_compatible>` to make "is self compatible with X".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -118,8 +118,8 @@ todo_include_todos = False
 # Markup to shorten external links
 # See https://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html
 extlinks = {
-    "gh": ("https://github.com/python-semver/python-semver/issues/%s", "#"),
-    "pr": ("https://github.com/python-semver/python-semver/pull/%s", "PR #"),
+    "gh": ("https://github.com/python-semver/python-semver/issues/%s", "#%s"),
+    "pr": ("https://github.com/python-semver/python-semver/pull/%s", "PR #%s"),
 }
 
 # -- Options for HTML output ----------------------------------------------

--- a/docs/migration/migratetosemver3.rst
+++ b/docs/migration/migratetosemver3.rst
@@ -3,8 +3,9 @@
 Migrating from semver2 to semver3
 =================================
 
-This document describes the visible differences for
+This section describes the visible differences for
 users and how your code stays compatible for semver3.
+Some changes are backward incompatible.
 
 Although the development team tries to make the transition
 to semver3 as smooth as possible, at some point change
@@ -34,9 +35,16 @@ Use semver.cli instead of semver
 --------------------------------
 
 All functions related to CLI parsing are moved to :mod:`semver.cli`.
-If you are such functions, like :func:`semver.cmd_bump <semver.cli.cmd_bump>`,
+If you need such functions, like :func:`semver.cmd_bump <semver.cli.cmd_bump>`,
 import it from :mod:`semver.cli` in the future:
 
 .. code-block:: python
 
    from semver.cli import cmd_bump
+
+
+Use semver.Version.is_valid instead of semver.Version.isvalid
+-------------------------------------------------------------
+
+The pull request :pr:`284` introduced the method :meth:`Version.is_compatible <semver.Version.is_compatible>`. To keep consistency, the development team
+decided to rename the :meth:`isvalid <semver.Version.isvalid>` to :meth:`is_valid <semver.Version.is_valid>`.

--- a/docs/migration/replace-deprecated-functions.rst
+++ b/docs/migration/replace-deprecated-functions.rst
@@ -31,6 +31,11 @@ them with code which is compatible for future versions:
 
   Likewise with the other module level functions.
 
+* :func:`semver.Version.isvalid`
+
+   Replace it with :meth:`semver.Version.is_valid`:
+
+
 * :func:`semver.finalize_version`
 
   Replace it with :func:`semver.Version.finalize_version`:

--- a/docs/usage/check-compatible-semver-version.rst
+++ b/docs/usage/check-compatible-semver-version.rst
@@ -1,0 +1,95 @@
+Checking for a Compatible Semver Version
+========================================
+
+To check if a *change* from a semver version ``a`` to a semver
+version ``b`` is *compatible* according to semver rule, use the method
+:meth:`Version.is_compatible <semver.version.Version.is_compatible>`.
+
+The expression ``a.is_compatible(b) is True`` if one of the following
+statements is true:
+
+* both versions are equal, or
+* both majors are equal and higher than 0. The same applies for both
+  minor parts. Both pre-releases are equal, or
+* both majors are equal and higher than 0. The minor of ``b``'s
+  minor version is higher then ``a``'s. Both pre-releases are equal.
+
+In all other cases, the result is false.
+
+Keep in mind, the method *does not* check patches!
+
+
+* Two different majors:
+
+  .. code-block:: python
+
+      >>> a = Version(1, 1, 1)
+      >>> b = Version(2, 0, 0)
+      >>> a.is_compatible(b)
+      False
+      >>> b.is_compatible(a)
+      False
+
+* Two different minors:
+
+  .. code-block:: python
+
+      >>> a = Version(1, 1, 0) 
+      >>> b = Version(1, 0, 0)
+      >>> a.is_compatible(b)
+      False
+      >>> b.is_compatible(a)
+      True
+
+* The same two majors and minors:
+
+  .. code-block:: python
+
+      >>> a = Version(1, 1, 1) 
+      >>> b = Version(1, 1, 0) 
+      >>> a.is_compatible(b)
+      True
+      >>> b.is_compatible(a)
+      True
+
+* Release and pre-release:
+
+  .. code-block:: python
+
+      >>> a = Version(1, 1, 1)
+      >>> b = Version(1, 0, 0,'rc1')
+      >>> a.is_compatible(b)
+      False
+      >>> b.is_compatible(a)
+      False
+
+* Different pre-releases:
+
+  .. code-block:: python
+
+      >>> a = Version(1, 0, 0, 'rc1')
+      >>> b = Version(1, 0, 0, 'rc2')
+      >>> a.is_compatible(b)
+      False
+      >>> b.is_compatible(a)
+      False
+
+* Identical pre-releases:
+
+  .. code-block:: python
+
+      >>> a = Version(1, 0, 0,'rc1')
+      >>> b = Version(1, 0, 0,'rc1')
+      >>> a.is_compatible(b)
+      True
+
+* All major zero versions are incompatible with anything but itself:
+
+  .. code-block:: python
+
+      >>> Version(0, 1, 0).is_compatible(Version(0, 1, 1))
+      False
+
+      # Only identical versions are compatible for major zero versions:
+      >>> Version(0, 1, 0).is_compatible(Version(0, 1, 0))
+      True

--- a/docs/usage/check-valid-semver-version.rst
+++ b/docs/usage/check-valid-semver-version.rst
@@ -6,7 +6,7 @@ classmethod :func:`Version.isvalid <semver.version.Version.isvalid>`:
 
 .. code-block:: python
 
-    >>> Version.isvalid("1.0.0")
+    >>> Version.is_valid("1.0.0")
     True
-    >>> Version.isvalid("invalid")
+    >>> Version.is_valid("invalid")
     False

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -8,6 +8,7 @@ Using semver
    create-a-version
    parse-version-string
    check-valid-semver-version
+   check-compatible-semver-version
    access-parts-of-a-version
    access-parts-through-index
    replace-parts-of-a-version

--- a/src/semver/cli.py
+++ b/src/semver/cli.py
@@ -54,7 +54,7 @@ def cmd_check(args: argparse.Namespace) -> None:
 
     :param args: The parsed arguments
     """
-    if Version.isvalid(args.version):
+    if Version.is_valid(args.version):
         return None
     raise ValueError("Invalid version %r" % args.version)
 

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -647,7 +647,7 @@ prerelease='pre.2', build='build.4')
             raise TypeError(error)
 
     @classmethod
-    def isvalid(cls, version: str) -> bool:
+    def is_valid(cls, version: str) -> bool:
         """
         Check if the string is a valid semver version.
 
@@ -662,6 +662,42 @@ prerelease='pre.2', build='build.4')
             return True
         except ValueError:
             return False
+
+    def is_compatible(self, other: "Version") -> bool:
+        """
+        Check if current version is compatible with other version.
+
+        The result is True, if either of the following is true:
+
+        * both versions are equal, or
+        * both majors are equal and higher than 0. Same for both minors.
+          Both pre-releases are equal, or
+        * both majors are equal and higher than 0. The minor of b's
+          minor version is higher then a's. Both pre-releases are equal.
+
+        The algorithm does *not* check patches.
+
+        :param other: the version to check for compatibility
+        :return: True, if ``other`` is compatible with the old version,
+                 otherwise False
+
+        >>> Version(1, 1, 0).is_compatible(Version(1, 0, 0))
+        False
+        >>> Version(1, 0, 0).is_compatible(Version(1, 1, 0))
+        True
+        """
+        if not isinstance(other, Version):
+            raise TypeError(f"Expected a Version type but got {type(other)}")
+
+        # All major-0 versions should be incompatible with anything but itself
+        if (0 == self.major == other.major) and (self[:4] != other[:4]):
+            return False
+
+        return (
+            (self.major == other.major)
+            and (other.minor >= self.minor)
+            and (self.prerelease == other.prerelease)
+        )
 
 
 #: Keep the VersionInfo name for compatibility

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,8 @@ python =
 
 [testenv]
 description = Run test suite for {basepython}
-allowlist_externals = make
 skip_install = true
+allowlist_externals = make
 commands = pytest {posargs:}
 deps =
     pytest


### PR DESCRIPTION
This is a first implementation of `Version.is_compatible`.

The algorithm checks:

* if the two majors are different, it's incompatible
* if the two majors are equal, but the minor of the callee is lower than the caller, it's incompatible
* if both prereleases are present and different, it's incompatible
* otherwise it's compatible

@rafalkrupinski /@sbrudenell / @Lexicality maybe you want to try/review it? :slightly_smiling_face: 

# TODOs
* [x] Improve changelog
* [x] Improve docstring with example(s)
* [x] Add missing documentation
* [x] Review code
* [x] Clarify naming