### PR TITLE
Fix #374: Adapt pyproject.tom for Towncrier

### DIFF
--- a/changelog.d/374.bugfix.rst
+++ b/changelog.d/374.bugfix.rst
@@ -1,0 +1,3 @@
+Correct Towncrier's config entries in the :file:`pyproject.toml` file.
+The old entries ``[[tool.towncrier.type]]`` are deprecated and need
+to be replaced by ``[tool.towncrier.fragment.<TYPE>]``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,42 +40,24 @@ template = "changelog.d/_template.rst"
 # issue_format = "`#{issue} <https://github.com/python-attrs/attrs/issues/{issue}>`_"
 # issue_format = ":gh:`{issue}`"
 
-  # [[tool.towncrier.type]]
-  # directory = "breaking"
-  # name = "Breaking Changes"
-  # showcontent = true
 
-  [[tool.towncrier.type]]
-  directory = "deprecation"
-  name = "Deprecations"
-  showcontent = true
+[tool.towncrier.fragment.breaking]
+name = "Breaking Changes"
 
-  [[tool.towncrier.type]]
-  directory = "feature"
-  name = "Features"
-  showcontent = true
+[tool.towncrier.fragment.bugfix]
+name = "Bug fixes"
 
-  # [[tool.towncrier.type]]
-  # directory = "improvement"
-  # name = "Improvements"
-  # showcontent = true
+[tool.towncrier.fragment.deprecation]
+name = "Deprecations"
 
-  [[tool.towncrier.type]]
-  directory = "bugfix"
-  name = "Bug Fixes"
-  showcontent = true
+[tool.towncrier.fragment.doc]
+name = "Improved documentation"
 
-  [[tool.towncrier.type]]
-  directory = "doc"
-  name = "Improved Documentation"
-  showcontent = true
+[tool.towncrier.fragment.feature]
+name = "Features"
 
-  [[tool.towncrier.type]]
-  directory = "trivial"
-  name = "Trivial/Internal Changes"
-  showcontent = true
+[tool.towncrier.fragment.removal]
+name = "Removals"
 
-  [[tool.towncrier.type]]
-  directory = "removal"
-  name = "Removals"
-  showcontent = true
+[tool.towncrier.fragment.trivial]
+name = "Trivial/Internal Changes"


### PR DESCRIPTION
* Replace the old, deprecated ``[[tool.towncrier.type]]`` entries with ``[tool.towncrier.fragment.<TYPE>]``. Described in https://towncrier.readthedocs.io/en/stable/configuration.html#deprecated-defining-custom-fragment-types-with-an-array-of-toml-tables
* Add a changelog news file

@Nagidal: would you like to review it, please? :pleading_face: 