### PR TITLE
Fix #372:  Remove support for Python 3.6

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -49,8 +49,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: ["3.6",
-                         "3.7",
+        python-version: ["3.7",
                          "3.8",
                          "3.9",
                          "3.10",

--- a/BUILDING.rst
+++ b/BUILDING.rst
@@ -12,7 +12,8 @@ Building semver
 This project changed slightly its way how it is built. The reason for this
 was to still support the "traditional" way with :command:`setup.py`,
 but at the same time try out the newer way with :file:`pyproject.toml`.
-Over time, once Python 3.6 gets deprecated, we will support only the newer way.
+As Python 3.6 got deprecated, this project does support from now on only
+:file:`pyproject.toml`.
 
 
 Background information

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -99,11 +99,11 @@ You can decide to run the complete test suite or only part of it:
      $ tox --skip-missing-interpreters
 
   It is possible to use one or more specific Python versions. Use the ``-e``
-  option and one or more abbreviations (``py36`` for Python 3.6, ``py37`` for
-  Python 3.7 etc.)::
+  option and one or more abbreviations (``py37`` for Python 3.7,
+  ``py38`` for Python 3.8 etc.)::
 
-      $ tox -e py36
-      $ tox -e py36,py37
+      $ tox -e py37
+      $ tox -e py37,py38
 
   To get a complete list and a short description, run::
 
@@ -116,7 +116,7 @@ You can decide to run the complete test suite or only part of it:
   :func:`test_immutable_major` in the file :file:`test_bump.py` for all
   Python versions::
 
-      $ tox -e py36 -- tests/test_bump.py::test_should_bump_major
+      $ tox -e py37 -- tests/test_bump.py::test_should_bump_major
 
   By default, pytest prints only a dot for each test function. To
   reveal the executed test function, use the following syntax::
@@ -124,16 +124,16 @@ You can decide to run the complete test suite or only part of it:
      $ tox -- -v
 
   You can combine the specific test function with the ``-e`` option, for
-  example, to limit the tests for Python 3.6 and 3.7 only::
+  example, to limit the tests for Python 3.7 and 3.8 only::
 
-      $ tox -e py36,py37 -- tests/test_bump.py::test_should_bump_major
+      $ tox -e py37,py38 -- tests/test_bump.py::test_should_bump_major
 
 Our code is checked against formatting, style, type, and docstring issues
 (`black`_, `flake8`_, `mypy`_, and `docformatter`_).
 It is recommended to run your tests in combination with :command:`checks`,
 for example::
 
-   $ tox -e checks,py36,py37
+   $ tox -e checks,py37,py38
 
 
 .. _doc:

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ A Python module for `semantic versioning`_. Simplifies comparing versions.
 
 .. note::
 
-   This project works for Python 3.6 and greater only. If you are
+   This project works for Python 3.7 and greater only. If you are
    looking for a compatible version for Python 2, use the
    maintenance branch |MAINT|_.
 
@@ -25,7 +25,7 @@ A Python module for `semantic versioning`_. Simplifies comparing versions.
    2.x.y However, keep in mind, the major 2 release is frozen: no new
    features nor backports will be integrated.
 
-   We recommend to upgrade your workflow to Python 3.x to gain support,
+   We recommend to upgrade your workflow to Python 3 to gain support,
    bugfixes, and new features.
 
 .. |MAINT| replace:: ``maint/v2``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 88
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 # diff = true
 extend-exclude = '''
 # A regex preceded with ^/ will apply only to files and directories

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,12 +26,12 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Software Development :: Libraries :: Python Modules
 license = BSD
 
@@ -39,7 +39,7 @@ license = BSD
 package_dir =
     =src
 packages = find:
-python_requires = >=3.6.*
+python_requires = >=3.7.*
 include_package_data = True
 
 [options.entry_points]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,0 @@
-#!/usr/bin/env python3
-import setuptools
-
-setuptools.setup()  # For compatibility with python 3.6

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
 envlist =
     checks
-    py3{6,7,8,9,10,11,12}
+    py3{7,8,9,10,11,12}
 isolated_build = True
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
-    3.6: py36
     # setuptools >=62 needs Python >=3.7
     3.7: py37,check
     3.8: py38
@@ -18,17 +17,14 @@ python =
 
 
 [testenv]
-description =
-    py36: Run a slightly different test suite for {basepython}
-    !py36: Run test suite for {basepython}
+description = Run test suite for {basepython}
 allowlist_externals = make
 commands = pytest {posargs:}
 deps =
     pytest
     pytest-cov
-    # py36: dataclasses
-    !py36: setuptools>=62.0
-    !py36: setuptools-scm
+    setuptools>=62.0
+    setuptools-scm
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
 
@@ -103,8 +99,11 @@ basepython = python3
 deps =
     wheel
     twine
+    # PEP 517 build frontend
+    build
 commands =
-    python3 setup.py sdist bdist_wheel
+    # Same as python3 -m build
+    pyproject-build
     twine check dist/*
 
 


### PR DESCRIPTION
Python 3.6 reached its end of life and isn't supported anymore. At the time of writing (Dec 2022), the lowest version is 3.7.
