### PR TITLE
General cleanup, reformat files

### DIFF
--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  # only cancel in-progress runs of the same workflow
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -259,8 +259,12 @@ fabric.properties
 # --------
 
 
-# Patch/Diff Files
-*.patch
-*.diff
+# Ignore files in the project's root:
+/*.patch
+/*.diff
+/*.py
+# but not this file:
+!/setup.py
+
 docs/_api
 !docs/_api/semver.__about__.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,4 +5,4 @@ include tests/test_*.py
 prune docs/_build
 recursive-exclude .github  *
 
-global-exclude *.py[cod] __pycache__ *.so *.dylib
+global-exclude __pycache__

--- a/changelog.d/pr384.bugfix.rst
+++ b/changelog.d/pr384.bugfix.rst
@@ -1,0 +1,11 @@
+General cleanup, reformat files:
+
+* Reformat source code with black again as some config options
+  did accidentely exclude the semver source code.
+  Mostly remove some includes/excludes in the black config.
+* Integrate concurrency in GH Action
+* Ignore Python files on project dirs in .gitignore
+* Remove unused patterns in MANIFEST.in
+* Use ``extend-exclude`` for flake in :file:`setup.cfg`` and adapt list.
+* Use ``skip_install=True`` in :file:`tox.ini` for black
+

--- a/docs/advanced/semverwithvprefix.py
+++ b/docs/advanced/semverwithvprefix.py
@@ -17,10 +17,8 @@ class SemVerWithVPrefix(Version):
         """
         if not version[0] in ("v", "V"):
             raise ValueError(
-                "{v!r}: not a valid semantic version tag. "
-                "Must start with 'v' or 'V'".format(
-                    v=version
-                )
+                f"{version!r}: not a valid semantic version tag. "
+                "Must start with 'v' or 'V'"
             )
         return super().parse(version[1:])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,7 @@ build-backend = "setuptools.build_meta"
 line-length = 88
 target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 # diff = true
-extend-exclude = '''
-# A regex preceded with ^/ will apply only to files and directories
-# in the root of the project.
-^/*.py
-'''
-include = '''
-^/setup.py
-'''
+
 
 [tool.towncrier]
 package = "semver"

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,10 +55,12 @@ semver = py.typed
 [tool:pytest]
 norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .eggs/ venv/
 testpaths = tests docs
+# pythonpath = src
 filterwarnings =
     ignore:Function 'semver.*:DeprecationWarning
     # ' <- This apostroph is just to fix syntax highlighting
 addopts =
+    # --import-mode=importlib
     --no-cov-on-fail
     --cov=semver
     --cov-report=term-missing
@@ -69,18 +71,15 @@ addopts =
 [flake8]
 max-line-length = 88
 ignore = F821,W503
-exclude =
-    src/semver/__init__.py
-    .env
-    venv
+extend-exclude =
     .eggs
-    .tox
-    .git
-    __pycache__
+    .env
     build
-    dist
     docs
+    venv
     conftest.py
+    src/semver/__init__.py
+    tasks.py
 
 [pycodestyle]
 count = False

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -69,8 +69,7 @@ class Version:
     #: Regex for number in a prerelease
     _LAST_NUMBER = re.compile(r"(?:[^\d]*(\d+)[^\d]*)+")
     #: Regex template for a semver version
-    _REGEX_TEMPLATE = \
-        r"""
+    _REGEX_TEMPLATE = r"""
             ^
             (?P<major>0|[1-9]\d*)
             (?:
@@ -93,12 +92,12 @@ class Version:
         """
     #: Regex for a semver version
     _REGEX = re.compile(
-        _REGEX_TEMPLATE.format(opt_patch='', opt_minor=''),
+        _REGEX_TEMPLATE.format(opt_patch="", opt_minor=""),
         re.VERBOSE,
     )
     #: Regex for a semver version that might be shorter
     _REGEX_OPTIONAL_MINOR_AND_PATCH = re.compile(
-        _REGEX_TEMPLATE.format(opt_patch='?', opt_minor='?'),
+        _REGEX_TEMPLATE.format(opt_patch="?", opt_minor="?"),
         re.VERBOSE,
     )
 
@@ -571,9 +570,7 @@ build='build.10')
 
     @classmethod
     def parse(
-        cls,
-        version: String,
-        optional_minor_and_patch: bool = False
+        cls, version: String, optional_minor_and_patch: bool = False
     ) -> "Version":
         """
         Parse version string to a Version instance.
@@ -611,10 +608,10 @@ prerelease='pre.2', build='build.4')
             raise ValueError(f"{version} is not valid SemVer string")
 
         matched_version_parts: Dict[str, Any] = match.groupdict()
-        if not matched_version_parts['minor']:
-            matched_version_parts['minor'] = 0
-        if not matched_version_parts['patch']:
-            matched_version_parts['patch'] = 0
+        if not matched_version_parts["minor"]:
+            matched_version_parts["minor"] = 0
+        if not matched_version_parts["patch"]:
+            matched_version_parts["patch"] = 0
 
         return cls(**matched_version_parts)
 

--- a/tests/test_match.py
+++ b/tests/test_match.py
@@ -60,9 +60,7 @@ def test_should_raise_value_error_for_unexpected_match_expression(left, right):
         match(left, right)
 
 
-@pytest.mark.parametrize(
-    "left,right", [("1.0.0", ""), ("1.0.0", "!")]
-)
+@pytest.mark.parametrize("left,right", [("1.0.0", ""), ("1.0.0", "!")])
 def test_should_raise_value_error_for_invalid_match_expression(left, right):
     with pytest.raises(ValueError):
         match(left, right)

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ setenv =
 [testenv:black]
 description = Check for formatting changes
 basepython = python3
+skip_install = true
 deps = black
 commands = black --check {posargs:.}
 


### PR DESCRIPTION
* Reformat source code with black again as some config options did accidentely exclude the semver source code. Mostly remove some includes/excludes in the black config.
* Integrate concurrency in GH Action
* Ignore Python files on project dirs in `.gitignore`
* Remove unused patterns in MANIFEST.in
* Use extend-exclude for flake in setup.cfg and adapt list.
* Use `skip_install=True` in `tox.ini` for black