### PR TITLE
tox/pytest: Add testpaths and use importlib

### DIFF
--- a/changelog.d/388.trivial.rst
+++ b/changelog.d/388.trivial.rst
@@ -1,0 +1,3 @@
+For pytest, switch to the more modern :mod:`importlib` approach
+as it doesn't require to modify :data:`sys.path`:
+https://docs.pytest.org/en/7.2.x/explanation/pythonpath.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,12 +55,12 @@ semver = py.typed
 [tool:pytest]
 norecursedirs = .git build .env/ env/ .pyenv/ .tmp/ .eggs/ venv/
 testpaths = tests docs
-# pythonpath = src
+pythonpath = src tests
 filterwarnings =
     ignore:Function 'semver.*:DeprecationWarning
     # ' <- This apostroph is just to fix syntax highlighting
 addopts =
-    # --import-mode=importlib
+    --import-mode=importlib
     --no-cov-on-fail
     --cov=semver
     --cov-report=term-missing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,6 @@ import pytest
 
 import semver
 
-# sys.path.insert(0, "docs/usage")
-
 from coerce import coerce  # noqa:E402
 from semverwithvprefix import SemVerWithVPrefix  # noqa:E402
 import packaging.version

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,7 @@ python =
 [testenv]
 description = Run test suite for {basepython}
 allowlist_externals = make
+skip_install = true
 commands = pytest {posargs:}
 deps =
     pytest


### PR DESCRIPTION
Switch to the more modern importlib approach as it doesn't require to modify `sys.path`:
https://docs.pytest.org/en/7.2.x/explanation/pythonpath.html