### PR TITLE
Fix pydantic/semver example

### DIFF
--- a/changelog.d/pr392.doc.rst
+++ b/changelog.d/pr392.doc.rst
@@ -1,0 +1,1 @@
+Fix the example in the documentation for combining semver and pydantic.

--- a/docs/advanced/combine-pydantic-and-semver.rst
+++ b/docs/advanced/combine-pydantic-and-semver.rst
@@ -18,9 +18,13 @@ To work with Pydantic, use the following steps:
 
         class PydanticVersion(Version):
             @classmethod
+            def _parse(cls, version):
+                return cls.parse(version)
+
+            @classmethod
             def __get_validators__(cls):
                 """Return a list of validator methods for pydantic models."""
-                yield cls.parse
+                yield cls._parse
 
             @classmethod
             def __modify_schema__(cls, field_schema):


### PR DESCRIPTION
The current example, when used with semver 3.0.0.dev4 and pydantic 1.10.4, produces the following error:

```
Traceback (most recent call last):
  File "/home/msalvatore/compost/semver_test/test.py", line 19, in <module>
    class MyModel(pydantic.BaseModel):
  File "pydantic/main.py", line 198, in pydantic.main.ModelMetaclass.__new__
  File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer
  File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__
  File "pydantic/fields.py", line 557, in pydantic.fields.ModelField.prepare
  File "pydantic/fields.py", line 834, in pydantic.fields.ModelField.populate_validators
  File "pydantic/class_validators.py", line 263, in pydantic.class_validators.prep_validators
  File "pydantic/class_validators.py", line 259, in pydantic.class_validators.make_generic_validator
  File "pydantic/class_validators.py", line 310, in pydantic.class_validators._generic_validator_basic
pydantic.errors.ConfigError: Invalid signature for validator <bound method Version.parse of <class '__main__.PydanticVersion'>>: (version: Union[str, bytes], optional_minor_and_patch: bool = False) -> 'Version', should be: (value, values, config, field), "values", "config" and "field" are all optional.
```

This commit fixes the example in the documentation so that it works and does not raise an error.