### PR TITLE
Fix: All `python -m semver` commands fail with 'error: invalid choice:'

### DIFF
--- a/src/semver/__main__.py
+++ b/src/semver/__main__.py
@@ -25,4 +25,4 @@ def main(cliargs: Optional[List[str]] = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
This was caused by \_\_main\_\_.py passing `sys.argv` to `cli.main()`, which includes the path of the script in `sys.argv[0]`. `argparse.ArgumentParser.parse_args()` parses this as the subcommand name, causing it to throw an error.

This could also be fixed by removing `sys.argv` entirely from [the arguments passed to `cli.main()`](https://github.com/python-semver/python-semver/blob/master/src/semver/__main__.py#L28), as [`argparse.ArgumentParser.parse_args()` will use `sys.argv[1:]` by default](https://github.com/python/cpython/blob/3.11/Lib/argparse.py#L1871).

I'm not sure if this change warrants an added test, as the existing tests cover `cli.main()` directly, but such a test would be reasonably straightforward to create and I can do so if you like.