### PR TITLE
Fix return type of classmethod parse

### DIFF
--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -14,6 +14,8 @@ from typing import (
     cast,
     Callable,
     Collection,
+    Type,
+    TypeVar,
 )
 
 from ._types import (
@@ -51,6 +53,9 @@ def _comparator(operator: Comparator) -> Comparator:
 def _cmp(a, b):  # TODO: type hints
     """Return negative if a<b, zero if a==b, positive if a>b."""
     return (a > b) - (a < b)
+
+
+T = TypeVar("T", bound="Version")
 
 
 class Version:
@@ -571,8 +576,8 @@ build='build.10')
 
     @classmethod
     def parse(
-        cls, version: String, optional_minor_and_patch: bool = False
-    ) -> "Version":
+        cls: Type[T], version: String, optional_minor_and_patch: bool = False
+    ) -> T:
         """
         Parse version string to a Version instance.
 

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -30,6 +30,8 @@ from ._types import (
 Comparable = Union["Version", Dict[str, VersionPart], Collection[VersionPart], str]
 Comparator = Callable[["Version", Comparable], bool]
 
+T = TypeVar("T", bound="Version")
+
 
 def _comparator(operator: Comparator) -> Comparator:
     """Wrap a Version binary op method in a type-check."""
@@ -53,9 +55,6 @@ def _comparator(operator: Comparator) -> Comparator:
 def _cmp(a, b):  # TODO: type hints
     """Return negative if a<b, zero if a==b, positive if a>b."""
     return (a > b) - (a < b)
-
-
-T = TypeVar("T", bound="Version")
 
 
 class Version:


### PR DESCRIPTION
So that calling parse on a derived class will show correct type of derived class