### PR TITLE
Fix #397: Remove asterisk in python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ license = BSD
 package_dir =
     =src
 packages = find:
-python_requires = >=3.7.*
+python_requires = >=3.7
 include_package_data = True
 
 [options.entry_points]


### PR DESCRIPTION
The asterisk in `python_requires = >= 3.7.*` of `setup.cfg` make the `pyproject-build` command fail with this exception:

    setuptools.extern.packaging.specifiers.InvalidSpecifier: Invalid specifier: '>=3.7.*'

This fix removes the asterisk which leads to a successful build.