### PR TITLE
Remove incorrect dependencies from build-system section of pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires = [
   # sync with setup.py until we discard non-pep-517/518
   "setuptools",
   "setuptools-scm",
-  "wheel",
   "build",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ requires = [
   # sync with setup.py until we discard non-pep-517/518
   "setuptools",
   "setuptools-scm",
-  "build",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/tox.ini
+++ b/tox.ini
@@ -99,10 +99,11 @@ commands = make -C docs man
 description = Prepare for TestPyPI
 basepython = python3
 deps =
-    wheel
     twine
-    # PEP 517 build frontend
-    build
+allowlist_externals =
+    # PEP 517 build frontend, automatically installed by setuptools
+    pyproject-build
+    twine
 commands =
     # Same as python3 -m build
     pyproject-build

--- a/tox.ini
+++ b/tox.ini
@@ -100,10 +100,7 @@ description = Prepare for TestPyPI
 basepython = python3
 deps =
     twine
-allowlist_externals =
-    # PEP 517 build frontend, automatically installed by setuptools
-    pyproject-build
-    twine
+    build
 commands =
     # Same as python3 -m build
     pyproject-build


### PR DESCRIPTION
Remove `wheel` and `build` dependencies from `pyproject.toml`. The former is added automatically by setuptools and is incorrect for sdist, the latter is frontend rather than backend.

(described in detail in commit messages)