### PR TITLE
correct typo in function description of `next_version`

### DIFF
--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -432,7 +432,7 @@ build='build.10')
         This function is taking prereleases into account.
         The "major", "minor", and "patch" raises the respective parts like
         the ``bump_*`` functions. The real difference is using the
-        "preprelease" part. It gives you the next patch version of the
+        "prerelease" part. It gives you the next patch version of the
         prerelease, for example:
 
         >>> str(semver.parse("0.1.4").next_version("prerelease"))


### PR DESCRIPTION
Hi! Thanks for creating the python package. I am actually using it and stumbled across this typo.