### PR TITLE
Configure docformatter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,15 @@ target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 # diff = true
 
 
+[tool.docformatter]
+wrap-summaries = 80
+close-quotes-on-newline = true
+# make-summary-multi-line = true
+black = true
+pre-summary-newline = true
+recursive = true
+
+
 [tool.towncrier]
 package = "semver"
 package_dir = "src"

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -64,8 +64,7 @@ class Version:
     See specification at https://semver.org.
 
     :param major: version when you make incompatible API changes.
-    :param minor: version when you add functionality in a backwards-
-        compatible manner.
+    :param minor: version when you add functionality in a backwards-compatible manner.
     :param patch: version when you make backwards-compatible bug fixes.
     :param prerelease: an optional prerelease string
     :param build: an optional build string

--- a/tox.ini
+++ b/tox.ini
@@ -56,7 +56,7 @@ commands = mypy {posargs:--ignore-missing-imports --check-untyped-defs src}
 description = Check for PEP257 compatible docstrings
 basepython = python3
 deps = docformatter
-commands = docformatter --check --diff {posargs:--pre-summary-newline -r src}
+commands = docformatter --check --diff {posargs:src}
 
 
 [testenv:checks]


### PR DESCRIPTION
* Add config options to `pyproject.toml`
* Call docformatter without any options in `tox.ini` as they are set in `pyproject.toml` now