### PR TITLE
Update doc string for python 3.12

### DIFF
--- a/docs/usage/convert-version-into-different-types.rst
+++ b/docs/usage/convert-version-into-different-types.rst
@@ -17,7 +17,7 @@ It is possible to convert a :class:`~semver.version.Version` instance:
 
     >>> v = Version(major=3, minor=4, patch=5)
     >>> v.to_dict()
-    OrderedDict([('major', 3), ('minor', 4), ('patch', 5), ('prerelease', None), ('build', None)])
+    OrderedDict({'major': 3, 'minor': 4, 'patch': 5, 'prerelease': None, 'build': None})
 
 * Into a tuple with :meth:`~semver.version.Version.to_tuple`::
 

--- a/docs/usage/create-a-version.rst
+++ b/docs/usage/create-a-version.rst
@@ -90,7 +90,7 @@ Depending on your use case, the following methods are available:
   To access individual parts, you can use the function :func:`semver.parse`::
 
     >>> semver.parse("3.4.5-pre.2+build.4")
-    OrderedDict([('major', 3), ('minor', 4), ('patch', 5), ('prerelease', 'pre.2'), ('build', 'build.4')])
+    OrderedDict({'major': 3, 'minor': 4, 'patch': 5, 'prerelease': 'pre.2', 'build': 'build.4'})
 
   If you pass an invalid version string you will get a :py:exc:`ValueError`::
 

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -228,8 +228,7 @@ class Version:
           ``patch``, ``prerelease``, and ``build``.
 
         >>> semver.Version(3, 2, 1).to_dict()
-        OrderedDict([('major', 3), ('minor', 2), ('patch', 1), \
-('prerelease', None), ('build', None)])
+        OrderedDict({'major': 3, 'minor': 4, 'patch': 5, 'prerelease': None, 'build': None})
         """
         return collections.OrderedDict(
             (


### PR DESCRIPTION
Resolves test failure with python3.12:

Failed [build](https://copr.fedorainfracloud.org/coprs/davidsch/testing/build/6147136/) and [log](https://download.copr.fedorainfracloud.org/results/davidsch/testing/fedora-rawhide-x86_64/06147136-python-semver/builder-live.log.gz)

Fixed [build](https://copr.fedorainfracloud.org/coprs/build/6147216) and [log](https://download.copr.fedorainfracloud.org/results/davidsch/testing/fedora-rawhide-x86_64/06147216-python-semver/builder-live.log.gz)