### PR TITLE
Return dict instead of OrderedDict

### DIFF
--- a/changelog.d/pr418.bugfix.rst
+++ b/changelog.d/pr418.bugfix.rst
@@ -1,0 +1,5 @@
+Replace :class:`~collection.OrderedDict` with :class:`dict`.
+
+The dict datatype is ordered since Python 3.7. As we do not support
+Python 3.6 anymore, it can be considered safe to avoid :class:`~collection.OrderedDict`.
+Related to :gh:`419`.

--- a/docs/usage/convert-version-into-different-types.rst
+++ b/docs/usage/convert-version-into-different-types.rst
@@ -17,7 +17,7 @@ It is possible to convert a :class:`~semver.version.Version` instance:
 
     >>> v = Version(major=3, minor=4, patch=5)
     >>> v.to_dict()
-    OrderedDict([('major', 3), ('minor', 4), ('patch', 5), ('prerelease', None), ('build', None)])
+    {'major': 3, 'minor': 4, 'patch': 5, 'prerelease': None, 'build': None}
 
 * Into a tuple with :meth:`~semver.version.Version.to_tuple`::
 

--- a/docs/usage/create-a-version.rst
+++ b/docs/usage/create-a-version.rst
@@ -90,7 +90,7 @@ Depending on your use case, the following methods are available:
   To access individual parts, you can use the function :func:`semver.parse`::
 
     >>> semver.parse("3.4.5-pre.2+build.4")
-    OrderedDict([('major', 3), ('minor', 4), ('patch', 5), ('prerelease', 'pre.2'), ('build', 'build.4')])
+    {'major': 3, 'minor': 4, 'patch': 5, 'prerelease': 'pre.2', 'build': 'build.4'}
 
   If you pass an invalid version string you will get a :py:exc:`ValueError`::
 

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -1,6 +1,5 @@
 """Version handling by a semver compatible version class."""
 
-import collections
 import re
 from functools import wraps
 from typing import (
@@ -218,27 +217,24 @@ class Version:
 
     def to_dict(self) -> VersionDict:
         """
-        Convert the Version object to an OrderedDict.
+        Convert the Version object to an dict.
 
         .. versionadded:: 2.10.0
            Renamed :meth:`Version._asdict` to :meth:`Version.to_dict` to
            make this function available in the public API.
 
-        :return: an OrderedDict with the keys in the order ``major``, ``minor``,
+        :return: an dict with the keys in the order ``major``, ``minor``,
           ``patch``, ``prerelease``, and ``build``.
 
         >>> semver.Version(3, 2, 1).to_dict()
-        OrderedDict([('major', 3), ('minor', 2), ('patch', 1), \
-('prerelease', None), ('build', None)])
+        {'major': 3, 'minor': 2, 'patch': 1, 'prerelease': None, 'build': None}
         """
-        return collections.OrderedDict(
-            (
-                ("major", self.major),
-                ("minor", self.minor),
-                ("patch", self.patch),
-                ("prerelease", self.prerelease),
-                ("build", self.build),
-            )
+        return dict(
+            major=self.major,
+            minor=self.minor,
+            patch=self.patch,
+            prerelease=self.prerelease,
+            build=self.build,
         )
 
     def __iter__(self) -> VersionIterator:


### PR DESCRIPTION
dict is guaranteed to preserver order in all supported versions

Replaces #418 