### PR TITLE
441 update docs

### DIFF
--- a/docs/advanced/combine-pydantic-and-semver.rst
+++ b/docs/advanced/combine-pydantic-and-semver.rst
@@ -9,7 +9,23 @@ According to its homepage, `Pydantic <https://pydantic-docs.helpmanual.io>`_
 "enforces type hints at runtime, and provides user friendly errors when data
 is invalid."
 
-To work with Pydantic>2.0, use the following steps:
+If you are working with Pydantic>2.0 and pydantic-extra-types>=2.10.0 you can use the built in `_VersionPydanticAnnotation` type, which wraps the `python-semver` `Version` type.
+
+    .. code-block:: python
+
+        from pydantic import BaseModel
+
+        from pydantic_extra_types.server import _VersionPydanticAnnotation
+
+        class appVersion(BaseModel):
+            version: _VersionPydanticAnnotation
+        
+        app_version = appVersion(version="1.2.3")
+
+        print(app_version.version)
+        # > 1.2.3
+
+To work with Pydantic>2.0 and without pydantic-extra-types you can use the following example to define your own type:
 
 
 1. Derive a new class from :class:`~semver.version.Version`


### PR DESCRIPTION
Small docs update, includes updated guidance on using Pydantic with `python-semver`.

Holding this in a draft state until the `_VersionPydanticAnnotation` is included in the next `pydantic-extra-types` release, probably version `2.10.0`.

Any and all feedback appreciated, cheers. 