### PR TITLE
Fix #460 Improve bump_prerelease to alway get a newer version

### DIFF
--- a/changelog.d/460.bugfix.rst
+++ b/changelog.d/460.bugfix.rst
@@ -1,0 +1,9 @@
+:meth:`~semver.version.Version.bump_prerelease` will now add `.0` to an
+existing prerelease when the last segment of the current prerelease, split by
+dots (`.`), is not numeric. This is to ensure the new prerelease is considered
+higher than the previous one.
+
+:meth:`~semver.version.Version.bump_prerelease` now also support an argument
+`bump_when_empty` which will bump the patch version if there is no existing
+prerelease, to ensure the resulting version is considered a higher version than
+the previous one.

--- a/docs/usage/raise-parts-of-a-version.rst
+++ b/docs/usage/raise-parts-of-a-version.rst
@@ -9,7 +9,7 @@ Raising Parts of a Version
    For example, having version ``1.0.0`` and raising the pre-release
    will lead to ``1.0.0-rc.1``, but ``1.0.0-rc.1`` is smaller than ``1.0.0``.
 
-   You can work around this by supplying the `bump_when_empty=true` argument to the
+   To avoid this, set `bump_when_empty=True` in the
    :meth:`~semver.version.Version.bump_prerelease` method, or by using the
    method :meth:`~semver.version.Version.next_version`
    in section :ref:`increase-parts-of-a-version`.
@@ -68,10 +68,9 @@ is not taken into account:
     >>> str(Version.parse("3.4.5-rc.1").bump_prerelease(''))
     '3.4.5-rc.2'
 
-If the last part of the existing prerelease, split by dots (`.`), is not numeric,
-we will add `.0` to ensure the new prerelease is higher than the previous one
-(otherwise, raising `rc9` to `rc10` would result in a lower version, as non-numeric
-parts are sorted alphabetically):
+To ensure correct ordering, we append `.0` to the last prerelease identifier
+if it's not numeric. This prevents cases where `rc9` would incorrectly sort
+lower than `rc10` (non-numeric identifiers are compared alphabetically):
 
 .. code-block:: python
 

--- a/docs/usage/raise-parts-of-a-version.rst
+++ b/docs/usage/raise-parts-of-a-version.rst
@@ -3,13 +3,14 @@ Raising Parts of a Version
 
 .. note::
 
-   Keep in mind, "raising" the pre-release only will make your
-   complete version *lower* than before.
+   Keep in mind, by default, "raising" the pre-release for a version without an existing
+   prerelease part, only will make your complete version *lower* than before.
 
    For example, having version ``1.0.0`` and raising the pre-release
    will lead to ``1.0.0-rc.1``, but ``1.0.0-rc.1`` is smaller than ``1.0.0``.
 
-   If you search for a way to take into account this behavior, look for the
+   You can work around this by supplying the `bump_when_empty=true` argument to the
+   :meth:`~semver.version.Version.bump_prerelease` method, or by using the
    method :meth:`~semver.version.Version.next_version`
    in section :ref:`increase-parts-of-a-version`.
 
@@ -67,4 +68,15 @@ is not taken into account:
     >>> str(Version.parse("3.4.5-rc.1").bump_prerelease(''))
     '3.4.5-rc.2'
 
+If the last part of the existing prerelease, split by dots (`.`), is not numeric,
+we will add `.0` to ensure the new prerelease is higher than the previous one
+(otherwise, raising `rc9` to `rc10` would result in a lower version, as non-numeric
+parts are sorted alphabetically):
+
+.. code-block:: python
+
+    >>> str(Version.parse("3.4.5-rc9").bump_prerelease())
+    '3.4.5-rc9.0'
+    >>> str(Version.parse("3.4.5-rc.9").bump_prerelease())
+    '3.4.5-rc.10'
 

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -255,7 +255,6 @@ class Version:
 
         :param string: the prerelease version to increment
         :return: the incremented string
-
         """
         match = Version._LAST_PRERELEASE.search(string)
         if match:
@@ -353,6 +352,8 @@ class Version:
         '1'
         >>> ver.bump_prerelease(None).prerelease
         'rc.1'
+        >>> str(ver.bump_prerelease(bump_when_empty=True))
+        '3.4.6-rc.1'
         """
         cls = type(self)
         patch = self._patch

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -334,7 +334,7 @@ class Version:
         Raise the prerelease part of the version, return a new object but leave
         self untouched.
 
-        .. versionchanged:: VERSION
+        .. versionchanged:: 3.1.0
            Parameter `bump_when_empty` added. When set to true, bumps the patch version
            when called with a version that has no prerelease segment, so the return
            value will be considered a newer version.

--- a/tests/test_bump.py
+++ b/tests/test_bump.py
@@ -6,6 +6,7 @@ from semver import (
     bump_minor,
     bump_patch,
     bump_prerelease,
+    compare,
     parse_version_info,
 )
 
@@ -32,62 +33,101 @@ def test_should_versioninfo_bump_minor_and_patch():
     v = parse_version_info("3.4.5")
     expected = parse_version_info("3.5.1")
     assert v.bump_minor().bump_patch() == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_patch_and_prerelease():
     v = parse_version_info("3.4.5-rc.1")
     expected = parse_version_info("3.4.6-rc.1")
     assert v.bump_patch().bump_prerelease() == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_patch_and_prerelease_with_token():
     v = parse_version_info("3.4.5-dev.1")
     expected = parse_version_info("3.4.6-dev.1")
     assert v.bump_patch().bump_prerelease("dev") == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_prerelease_and_build():
     v = parse_version_info("3.4.5-rc.1+build.1")
     expected = parse_version_info("3.4.5-rc.2+build.2")
     assert v.bump_prerelease().bump_build() == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_prerelease_and_build_with_token():
     v = parse_version_info("3.4.5-rc.1+b.1")
     expected = parse_version_info("3.4.5-rc.2+b.2")
     assert v.bump_prerelease().bump_build("b") == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_multiple():
     v = parse_version_info("3.4.5-rc.1+build.1")
     expected = parse_version_info("3.4.5-rc.2+build.2")
     assert v.bump_prerelease().bump_build().bump_build() == expected
+    assert v.compare(expected) == -1
     expected = parse_version_info("3.4.5-rc.3")
     assert v.bump_prerelease().bump_build().bump_build().bump_prerelease() == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_prerelease_with_empty_str():
     v = parse_version_info("3.4.5")
     expected = parse_version_info("3.4.5-1")
     assert v.bump_prerelease("") == expected
+    assert v.compare(expected) == 1
 
 
 def test_should_versioninfo_bump_prerelease_with_none():
     v = parse_version_info("3.4.5")
     expected = parse_version_info("3.4.5-rc.1")
     assert v.bump_prerelease(None) == expected
+    assert v.compare(expected) == 1
+
+
+def test_should_versioninfo_bump_prerelease_nonnumeric():
+    v = parse_version_info("3.4.5-rc1")
+    expected = parse_version_info("3.4.5-rc1.0")
+    assert v.bump_prerelease(None) == expected
+    assert v.compare(expected) == -1
+
+
+def test_should_versioninfo_bump_prerelease_nonnumeric_nine():
+    v = parse_version_info("3.4.5-rc9")
+    expected = parse_version_info("3.4.5-rc9.0")
+    assert v.bump_prerelease(None) == expected
+    assert v.compare(expected) == -1
+
+
+def test_should_versioninfo_bump_prerelease_bump_patch():
+    v = parse_version_info("3.4.5")
+    expected = parse_version_info("3.4.6-rc.1")
+    assert v.bump_prerelease(bump_when_empty=True) == expected
+    assert v.compare(expected) == -1
+
+
+def test_should_versioninfo_bump_patch_and_prerelease_bump_patch():
+    v = parse_version_info("3.4.5")
+    expected = parse_version_info("3.4.7-rc.1")
+    assert v.bump_patch().bump_prerelease(bump_when_empty=True) == expected
+    assert v.compare(expected) == -1
 
 
 def test_should_versioninfo_bump_build_with_empty_str():
     v = parse_version_info("3.4.5")
     expected = parse_version_info("3.4.5+1")
     assert v.bump_build("") == expected
+    assert v.compare(expected) == 0
 
 
 def test_should_versioninfo_bump_build_with_none():
     v = parse_version_info("3.4.5")
     expected = parse_version_info("3.4.5+build.1")
     assert v.bump_build(None) == expected
+    assert v.compare(expected) == 0
 
 
 def test_should_ignore_extensions_for_bump():
@@ -95,18 +135,18 @@ def test_should_ignore_extensions_for_bump():
 
 
 @pytest.mark.parametrize(
-    "version,token,expected",
+    "version,token,expected,expected_compare",
     [
-        ("3.4.5-rc.9", None, "3.4.5-rc.10"),
-        ("3.4.5", None, "3.4.5-rc.1"),
-        ("3.4.5", "dev", "3.4.5-dev.1"),
-        ("3.4.5", "", "3.4.5-rc.1"),
+        ("3.4.5-rc.9", None, "3.4.5-rc.10", -1),
+        ("3.4.5", None, "3.4.5-rc.1", 1),
+        ("3.4.5", "dev", "3.4.5-dev.1", 1),
+        ("3.4.5", "", "3.4.5-rc.1", 1),
     ],
 )
-def test_should_bump_prerelease(version, token, expected):
+def test_should_bump_prerelease(version, token, expected, expected_compare):
     token = "rc" if not token else token
     assert bump_prerelease(version, token) == expected
-
+    assert compare(version, expected) == expected_compare
 
 def test_should_ignore_build_on_prerelease_bump():
     assert bump_prerelease("3.4.5-rc.1+build.4") == "3.4.5-rc.2"
@@ -123,3 +163,4 @@ def test_should_ignore_build_on_prerelease_bump():
 )
 def test_should_bump_build(version, expected):
     assert bump_build(version) == expected
+    assert compare(version, expected) == 0

--- a/tests/test_pysemver-cli.py
+++ b/tests/test_pysemver-cli.py
@@ -55,7 +55,7 @@ def test_should_parse_cli_arguments(cli, expected):
         (
             cmd_bump,
             Namespace(bump="prerelease", version="1.2.3-rc1"),
-            does_not_raise("1.2.3-rc2"),
+            does_not_raise("1.2.3-rc1.0"),
         ),
         (
             cmd_bump,

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps =
     setuptools-scm
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK = 1
+downloads = true
 
 
 [testenv:mypy]


### PR DESCRIPTION
This PR fixes #460 and contains the following changes:
* Bumping an existing prerelease always results in a newer prerelease
* Bumping an empty prerelease can optionally bump the patch version to ensure a newer version

I ran the test suites successfully, except for 'checks', which also failed before I made any change. I ensured I did not introduce any new errors in this suite. I also added quite a bunch of tests to validate the new functionality, and adjusted a few that changed due to changing existing functionality.

Open to any suggestions for improvement, as my Python experience is a bit limited :-)