### PR TITLE
Fix #466: CLI pass token for prerelease and build

### DIFF
--- a/src/semver/cli.py
+++ b/src/semver/cli.py
@@ -40,10 +40,16 @@ def cmd_bump(args: argparse.Namespace) -> str:
         # print the help and exit
         args.parser.parse_args(["bump", "-h"])
 
+    # print(">>> args:", args)
+
     ver = Version.parse(args.version)
     # get the respective method and call it
     func = getattr(ver, maptable[cast(str, args.bump)])
-    return str(func())
+    if args.bump in ("prerelease", "build"):
+        fargs = {"token": args.token}
+    else:
+        fargs = {}
+    return str(func(**fargs))
 
 
 def cmd_check(args: argparse.Namespace) -> None:
@@ -108,13 +114,14 @@ def createparser() -> argparse.ArgumentParser:
     sb = parser_bump.add_subparsers(title="Bump commands", dest="bump")
 
     # Create subparsers for the bump subparser:
-    for p in (
-        sb.add_parser("major", help="Bump the major part of the version"),
-        sb.add_parser("minor", help="Bump the minor part of the version"),
-        sb.add_parser("patch", help="Bump the patch part of the version"),
-        sb.add_parser("prerelease", help="Bump the prerelease part of the version"),
-        sb.add_parser("build", help="Bump the build part of the version"),
-    ):
+    maptable = {"prerelease": "rc", "build": "build"}
+    for item in ("major", "minor", "patch", "prerelease", "build"):
+        p = sb.add_parser(item, help="Bump the {} part of the version".format(item))
+        if item in ("prerelease", "build"):
+            p.add_argument("--token",
+                           default=maptable.get(item),
+                           help="The token to use for {}".format(item))
+
         p.add_argument("version", help="Version to raise")
 
     # Create the check subcommand

--- a/tests/test_pysemver-cli.py
+++ b/tests/test_pysemver-cli.py
@@ -23,14 +23,30 @@ def does_not_raise(item):
 @pytest.mark.parametrize(
     "cli,expected",
     [
-        (["bump", "major", "1.2.3"], Namespace(bump="major", version="1.2.3")),
-        (["bump", "minor", "1.2.3"], Namespace(bump="minor", version="1.2.3")),
-        (["bump", "patch", "1.2.3"], Namespace(bump="patch", version="1.2.3")),
         (
-            ["bump", "prerelease", "1.2.3"],
-            Namespace(bump="prerelease", version="1.2.3"),
+            ["bump", "major", "1.2.3"],
+            Namespace(bump="major", version="1.2.3"),
         ),
-        (["bump", "build", "1.2.3"], Namespace(bump="build", version="1.2.3")),
+        (
+            ["bump", "minor", "2.3.4"],
+            Namespace(bump="minor", version="2.3.4"),
+        ),
+        (
+            ["bump", "patch", "3.4.5"],
+            Namespace(bump="patch", version="3.4.5"),
+        ),
+        (
+            ["bump", "prerelease", "4.5.6"],
+            Namespace(
+                bump="prerelease",
+                token="rc",
+                version="4.5.6",
+            ),
+        ),
+        (
+            ["bump", "build", "5.6.7"],
+            Namespace(bump="build", token="build", version="5.6.7"),
+        ),
         # ---
         (["compare", "1.2.3", "2.1.3"], Namespace(version1="1.2.3", version2="2.1.3")),
         # ---
@@ -54,12 +70,12 @@ def test_should_parse_cli_arguments(cli, expected):
         (cmd_bump, Namespace(bump="patch", version="1.2.3"), does_not_raise("1.2.4")),
         (
             cmd_bump,
-            Namespace(bump="prerelease", version="1.2.3-rc1"),
+            Namespace(bump="prerelease", version="1.2.3-rc1", token="rc"),
             does_not_raise("1.2.3-rc1.0"),
         ),
         (
             cmd_bump,
-            Namespace(bump="build", version="1.2.3+build.13"),
+            Namespace(bump="build", version="1.2.3+build.13", token="rc"),
             does_not_raise("1.2.3+build.14"),
         ),
         # compare subcommand


### PR DESCRIPTION
For the CLI pysemver script, this change introduces a `--token` option when bumping prereleases or builds.