### PR TITLE
fix: next_version should bump version for build-only versions

### DIFF
--- a/docs/usage/increase-parts-of-a-version_prereleases.rst
+++ b/docs/usage/increase-parts-of-a-version_prereleases.rst
@@ -19,6 +19,6 @@ would perhaps a better fit.
     >>> str(Version.parse("3.4.5-pre.2+build.4").next_version(part="patch"))
     '3.4.5'
     >>> str(Version.parse("3.4.5+build.4").next_version(part="patch"))
-    '3.4.5'
+    '3.4.6'
     >>> str(Version.parse("0.1.4").next_version("prerelease"))
     '0.1.5-rc.1'

--- a/src/semver/version.py
+++ b/src/semver/version.py
@@ -471,7 +471,7 @@ build='build.10')
                 f"Invalid part. Expected one of {validparts}, but got {part!r}"
             )
         version = self
-        if (version.prerelease or version.build) and (
+        if version.prerelease and (
             part == "patch"
             or (part == "minor" and version.patch == 0)
             or (part == "major" and version.minor == version.patch == 0)

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -198,6 +198,16 @@ def test_next_version_with_invalid_parts():
         ("0.2.0-rc.1", "patch", "0.2.0"),  # same as "minor"
         ("1.0.0-rc.1", "patch", "1.0.0"),  # same as "major"
         ("1.0.0-rc.1", "minor", "1.0.0"),  # same as "major"
+        # build-only versions: build metadata does not affect precedence,
+        # so next_version should bump the version, not just strip the build
+        ("1.2.3+build.5", "patch", "1.2.4"),
+        ("1.0.0+build.5", "patch", "1.0.1"),
+        ("0.1.4+build.5", "patch", "0.1.5"),
+        ("1.2.0+build.5", "minor", "1.3.0"),
+        ("1.0.0+build.5", "major", "2.0.0"),
+        # prerelease+build: build is stripped along with prerelease during finalization
+        ("1.2.3-rc.1+build.5", "patch", "1.2.3"),
+        ("1.2.3-rc.1+build.5", "prerelease", "1.2.3-rc.2"),
     ],
 )
 def test_next_version_with_versioninfo(version, part, expected):


### PR DESCRIPTION
Fixes a bug where `next_version` on versions with build metadata but no prerelease would strip the build without bumping the version.

## Bug

`Version.parse('1.2.3+build.5').next_version('patch')` returns `1.2.3` instead of `1.2.4`.

The condition in `next_version` was `(version.prerelease or version.build)`, which caused build-only versions to enter the finalization path meant for prereleases. Build metadata does not affect semver precedence, so its presence should not trigger version finalization -- the version should be bumped.

Same issue affects `next_version('minor')` on X.Y.0+build and `next_version('major')` on X.0.0+build.

## Fix

Change the condition from `version.prerelease or version.build` to `version.prerelease`. Prerelease+build versions still correctly finalize (stripping both prerelease and build).

## Checklist

- [x] One-line fix in `version.py`
- [x] 7 new test cases covering build-only and prerelease+build scenarios
- [x] All 340 existing+tests pass (100% coverage)